### PR TITLE
Named Attributes

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2/econdata.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/econdata.sp
@@ -77,6 +77,7 @@ bool TF2ED_GetLocalizedItemName(int itemdef, char[] name, int maxlen, const char
 		if(slot >= 0 && slot < sizeof(SlotNames))
 			return view_as<bool>(strcopy(name, maxlen, SlotNames[slot]));
 	}
+	
 	return false;
 }
 

--- a/addons/sourcemod/scripting/freak_fortress_2/stocks.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/stocks.sp
@@ -1006,6 +1006,19 @@ public int GetBossQueueSort(int elem1, int elem2, const int[] array, Handle hndl
 	return (elem1 > elem2) ? 1 : -1;
 }
 
+stock bool IsClientValid(int client)
+{
+    if(client <= 0 || client > MaxClients)
+        return false;
+
+    if(!IsClientInGame(client))
+        return false;
+
+    if(GetEntProp(client, Prop_Send, "m_bIsCoaching"))
+        return false;
+    
+    return true;
+}
 /*void DeleteCfg2(ConfigMap cfg)
 {
 	ConfigMap cfg2 = cfg;


### PR DESCRIPTION
Give the possibility to server owners to specify weapon attributes by name and not only by ID.
This does NOT apply to bosses as they use a different function. We should make the attribute parsing into their own functions so we don't have to rewrite the same logic in two different places.


I've also added a new stock: IsClientValid.
It's to avoid having a long line to check whether or not the client is valid.

#4