### PR TITLE
Proper way to strip attributes

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2/weapons.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/weapons.sp
@@ -521,45 +521,47 @@ public void Weapons_SpawnFrame(int ref)
 		char valueType[2];
 		char valueFormat[64];
 
-		int currentAttrib;
+		int staticAttribs[16];
+		float staticAttribsValues[16];
 
-		ArrayList staticAttribs = TF2Econ_GetItemStaticAttributes(GetEntProp(entity, Prop_Send, "m_iItemDefinitionIndex"));
+		int itemDefIndex = GetEntProp(entity, Prop_Send, "m_iItemDefinitionIndex");
 
-		for(int i = 0; i < staticAttribs.Length; i++)
+		TF2Attrib_GetStaticAttribs(itemDefIndex, staticAttribs, staticAttribsValues);
+
+		for(int i = 0; i < 16; i++)
 		{
-			currentAttrib = staticAttribs.Get(i, .block = 0);
+			if(staticAttribs[i] == 0)
+				continue;
 
 			// Probably overkill
-			if(currentAttrib == 796 || currentAttrib == 724 || currentAttrib == 817 || currentAttrib == 834 
-				|| currentAttrib == 745 || currentAttrib == 731 || currentAttrib == 746)
+			if(staticAttribs[i] == 796 || staticAttribs[i] == 724 || staticAttribs[i] == 817 || staticAttribs[i] == 834 
+				|| staticAttribs[i] == 745 || staticAttribs[i] == 731 || staticAttribs[i] == 746)
 				continue;
 
 			// "stored_as_integer" is absent from the attribute schema if its type is "string".
 			// TF2ED_GetAttributeDefinitionString returns false if it can't find the given string.
-			if(!TF2ED_GetAttributeDefinitionString(currentAttrib, "stored_as_integer", valueType, sizeof(valueType)))
+			if(!TF2ED_GetAttributeDefinitionString(staticAttribs[i], "stored_as_integer", valueType, sizeof(valueType)))
 				continue;
 
-			TF2ED_GetAttributeDefinitionString(currentAttrib, "description_format", valueFormat, sizeof(valueFormat));
+			TF2ED_GetAttributeDefinitionString(staticAttribs[i], "description_format", valueFormat, sizeof(valueFormat));
 
 			// Since we already know what we're working with and what we're looking for, we can manually handpick
 			// the most significative chars to check if they match. Eons faster than doing StrEqual or StrContains.
 
 			if(valueFormat[9] == 'a' && valueFormat[10] == 'd') // value_is_additive & value_is_additive_percentage
 			{
-				TF2Attrib_SetByDefIndex(entity, currentAttrib, 0.0);
+				TF2Attrib_SetByDefIndex(entity, staticAttribs[i], 0.0);
 			}
 			else if((valueFormat[9] == 'i' && valueFormat[18] == 'p')
 				|| (valueFormat[9] == 'p' && valueFormat[10] == 'e')) // value_is_percentage & value_is_inverted_percentage
 			{
-				TF2Attrib_SetByDefIndex(entity, currentAttrib, 1.0);
+				TF2Attrib_SetByDefIndex(entity, staticAttribs[i], 1.0);
 			}
 			else if(valueFormat[9] == 'o' && valueFormat[10] == 'r') // value_is_or
 			{
-				TF2Attrib_SetByDefIndex(entity, currentAttrib, 0.0);
+				TF2Attrib_SetByDefIndex(entity, staticAttribs[i], 0.0);
 			}
 		}
-
-		delete staticAttribs;
 	}
 
 	int current = 0;


### PR DESCRIPTION
The only way to maintain attributes such as min_viewmodel_offset is to not remove them in the first place. We have to manually nullify all the static attributes the weapon has.

I've tested it and it works fine. Though, I have no way to properly test all the edge cases ( if they exist in the first place ).