### PR TITLE
Move SDKHook_LibraryAdded and ...Removed

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -339,7 +339,7 @@ public void OnPluginEnd()
 
 public void OnLibraryAdded(const char[] name)
 {
-	SDKHook_LibraryRemoved(name);
+	SDKHook_LibraryAdded(name);
 	TF2U_LibraryAdded(name);
 	TFED_LibraryAdded(name);
 	Weapons_LibraryAdded(name);
@@ -347,7 +347,7 @@ public void OnLibraryAdded(const char[] name)
 
 public void OnLibraryRemoved(const char[] name)
 {
-	SDKHook_LibraryAdded(name);
+	SDKHook_LibraryRemoved(name);
 	TF2U_LibraryRemoved(name);
 	TFED_LibraryRemoved(name);
 	Weapons_LibraryRemoved(name);


### PR DESCRIPTION
This would cause TF_OnTakeDamage to get called twice since the logic of checking whether or not the library exists was messed up