### PR TITLE
Add player glow to last player on team (configurable)

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -186,6 +186,7 @@ ConVar CvarAggressiveSwap;
 ConVar CvarAggressiveOverlay;
 ConVar CvarSoundType;
 ConVar CvarDisguiseModels;
+ConVar CvarPlayerGlow;
 
 ConVar CvarAllowSpectators;
 ConVar CvarMovementFreeze;

--- a/addons/sourcemod/scripting/freak_fortress_2/commands.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/commands.sp
@@ -304,6 +304,11 @@ public Action Command_EurekaTeleport(int client, const char[] command, int args)
 {
 	if(Enabled && RoundStatus == 1 && IsPlayerAlive(client))
 	{
+		char buffer[4];
+		GetCmdArg(1, buffer, sizeof(buffer));
+		if (StringToInt(buffer) == 0)
+			return Plugin_Handled;
+
 		int entity = MaxClients + 1;
 		while((entity = FindEntityByClassname(entity, "obj_teleporter")) != -1)
 		{
@@ -311,9 +316,7 @@ public Action Command_EurekaTeleport(int client, const char[] command, int args)
 			{
 				if(!GetEntProp(entity, Prop_Send, "m_bBuilding"))
 				{
-					char buffer[4];
-					GetCmdArg(1, buffer, sizeof(buffer));
-					if(StringToInt(buffer) == 0)
+					if(StringToInt(buffer) == 1)
 						return Plugin_Continue;
 				}
 				break;

--- a/addons/sourcemod/scripting/freak_fortress_2/commands.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/commands.sp
@@ -306,7 +306,8 @@ public Action Command_EurekaTeleport(int client, const char[] command, int args)
 	{
 		char buffer[4];
 		GetCmdArg(1, buffer, sizeof(buffer));
-		if (StringToInt(buffer) == 0)
+		int teletype = StringToInt(buffer);
+		if (teletype == 0)
 			return Plugin_Handled;
 
 		int entity = MaxClients + 1;
@@ -316,7 +317,7 @@ public Action Command_EurekaTeleport(int client, const char[] command, int args)
 			{
 				if(!GetEntProp(entity, Prop_Send, "m_bBuilding"))
 				{
-					if(StringToInt(buffer) == 1)
+					if(teletype == 1)
 						return Plugin_Continue;
 				}
 				break;

--- a/addons/sourcemod/scripting/freak_fortress_2/commands.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/commands.sp
@@ -306,24 +306,26 @@ public Action Command_EurekaTeleport(int client, const char[] command, int args)
 	{
 		char buffer[4];
 		GetCmdArg(1, buffer, sizeof(buffer));
-		int teletype = StringToInt(buffer);
-		if (teletype == 0)
-			return Plugin_Handled;
-
-		int entity = MaxClients + 1;
-		while((entity = FindEntityByClassname(entity, "obj_teleporter")) != -1)
+		if ( StringToInt(buffer) == 0)
 		{
-			if(GetEntPropEnt(entity, Prop_Send, "m_hBuilder") == client && GetEntProp(entity, Prop_Send, "m_iObjectMode") == view_as<int>(TFObjectMode_Exit))
-			{
-				if(!GetEntProp(entity, Prop_Send, "m_bBuilding"))
-				{
-					if(teletype == 1)
-						return Plugin_Continue;
-				}
-				break;
-			}
+			return Plugin_Handled;
 		}
-		return Plugin_Handled;
+		else
+		{
+			int entity = MaxClients + 1;
+			while((entity = FindEntityByClassname(entity, "obj_teleporter")) != -1)
+			{
+				if(GetEntPropEnt(entity, Prop_Send, "m_hBuilder") == client && GetEntProp(entity, Prop_Send, "m_iObjectMode") == view_as<int>(TFObjectMode_Exit))
+				{
+					if(!GetEntProp(entity, Prop_Send, "m_bBuilding"))
+					{
+						return Plugin_Continue;
+					}
+					break;
+				}
+			}
+			return Plugin_Handled;
+		}
 	}
 	return Plugin_Continue;
 }

--- a/addons/sourcemod/scripting/freak_fortress_2/commands.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/commands.sp
@@ -313,7 +313,7 @@ public Action Command_EurekaTeleport(int client, const char[] command, int args)
 				{
 					char buffer[4];
 					GetCmdArg(1, buffer, sizeof(buffer));
-					if(StringToInt(buffer) == 1)
+					if(StringToInt(buffer) == 0)
 						return Plugin_Continue;
 				}
 				break;

--- a/addons/sourcemod/scripting/freak_fortress_2/convars.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/convars.sp
@@ -41,7 +41,7 @@ void ConVar_PluginStart()
 	CvarAggressiveOverlay = CreateConVar("ff2_aggressive_overlay", "0", "Force clears overlays on death and round end.\nOnly use if you have subplugin issues not cleaing overlays, even then you should fix them anyways", _, true, 0.0, true, 1.0);
 	CvarSoundType = CreateConVar("ff2_boss_globalsounds", "0", "If default sounds are globally heard", _, true, 0.0, true, 1.0);
 	CvarDisguiseModels = CreateConVar("ff2_game_disguises", "1", "If to use rome vision to apply custom models to disguises.\nChanges won't apply right away, recommended only to change with a map restart.", _, true, 0.0, true, 1.0);
-	
+	CvarPlayerGlow = CreateConVar("ff2_game_last_glow", "1", "If the final mercenary of a team will be highlighted.", _, true, 0.0, true, 1.0);
 	CreateConVar("ff2_oldjump", "1", "Backwards Compatibility ConVar", FCVAR_DONTRECORD|FCVAR_HIDDEN, true, 0.0, true, 1.0);
 	CreateConVar("ff2_base_jumper_stun", "0", "Backwards Compatibility ConVar", FCVAR_DONTRECORD|FCVAR_HIDDEN, true, 0.0, true, 1.0);
 	CreateConVar("ff2_solo_shame", "1", "Backwards Compatibility ConVar", FCVAR_DONTRECORD|FCVAR_HIDDEN, true, 0.0, true, 1.0);

--- a/addons/sourcemod/scripting/freak_fortress_2/convars.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/convars.sp
@@ -42,6 +42,7 @@ void ConVar_PluginStart()
 	CvarSoundType = CreateConVar("ff2_boss_globalsounds", "0", "If default sounds are globally heard", _, true, 0.0, true, 1.0);
 	CvarDisguiseModels = CreateConVar("ff2_game_disguises", "1", "If to use rome vision to apply custom models to disguises.\nChanges won't apply right away, recommended only to change with a map restart.", _, true, 0.0, true, 1.0);
 	CvarPlayerGlow = CreateConVar("ff2_game_last_glow", "1", "If the final mercenary of a team will be highlighted.", _, true, 0.0, true, 1.0);
+	
 	CreateConVar("ff2_oldjump", "1", "Backwards Compatibility ConVar", FCVAR_DONTRECORD|FCVAR_HIDDEN, true, 0.0, true, 1.0);
 	CreateConVar("ff2_base_jumper_stun", "0", "Backwards Compatibility ConVar", FCVAR_DONTRECORD|FCVAR_HIDDEN, true, 0.0, true, 1.0);
 	CreateConVar("ff2_solo_shame", "1", "Backwards Compatibility ConVar", FCVAR_DONTRECORD|FCVAR_HIDDEN, true, 0.0, true, 1.0);

--- a/addons/sourcemod/scripting/freak_fortress_2/gamemode.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/gamemode.sp
@@ -955,8 +955,13 @@ void Gamemode_PlayerRunCmd(int client)
 			if(PlayersAlive[team] < 3)
 				TF2_AddCondition(client, TF2_GetPlayerClass(client) == TFClass_Scout ? TFCond_Buffed : TFCond_CritCola, 0.5);
 			
-			if(PlayersAlive[team] < 2)
+			if(PlayersAlive[team] < 2) {
 				TF2_AddCondition(client, TFCond_CritOnDamage, 0.5);
+				if (CvarPlayerGlow.BoolValue)
+				{
+					Gamemode_SetClientGlow(client, 5.0);
+				}
+			}
 		}
 		
 		if(Client(client).Glowing)

--- a/addons/sourcemod/scripting/freak_fortress_2/gamemode.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/gamemode.sp
@@ -955,7 +955,8 @@ void Gamemode_PlayerRunCmd(int client)
 			if(PlayersAlive[team] < 3)
 				TF2_AddCondition(client, TF2_GetPlayerClass(client) == TFClass_Scout ? TFCond_Buffed : TFCond_CritCola, 0.5);
 			
-			if(PlayersAlive[team] < 2) {
+			if(PlayersAlive[team] < 2) 
+			{
 				TF2_AddCondition(client, TFCond_CritOnDamage, 0.5);
 				if (CvarPlayerGlow.BoolValue)
 				{


### PR DESCRIPTION
If the convar is enabled the last player on a team (bosses excluded) is highlighted to make it easier to move the end of the round along especially if the last player is hiding from the boss.