### PR TITLE
Enable Cap ConVar

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -182,6 +182,7 @@ ConVar CvarPrefBlacklist;
 ConVar CvarPrefToggle;
 ConVar CvarCaptureTime;
 ConVar CvarCaptureAlive;
+ConVar CvarEnableCapture;
 ConVar CvarAggressiveSwap;
 ConVar CvarAggressiveOverlay;
 ConVar CvarSoundType;

--- a/addons/sourcemod/scripting/freak_fortress_2/convars.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/convars.sp
@@ -41,6 +41,7 @@ void ConVar_PluginStart()
 	CvarAggressiveOverlay = CreateConVar("ff2_aggressive_overlay", "0", "Force clears overlays on death and round end.\nOnly use if you have subplugin issues not cleaing overlays, even then you should fix them anyways", _, true, 0.0, true, 1.0);
 	CvarSoundType = CreateConVar("ff2_boss_globalsounds", "0", "If default sounds are globally heard", _, true, 0.0, true, 1.0);
 	CvarDisguiseModels = CreateConVar("ff2_game_disguises", "1", "If to use rome vision to apply custom models to disguises.\nChanges won't apply right away, recommended only to change with a map restart.", _, true, 0.0, true, 1.0);
+	CvarEnableCapture = CreateConVar("ff2_game_enable_capture", "1", "Enables the control point to be captured by players", _, true, 0.0, true, 1.0);
 	CvarPlayerGlow = CreateConVar("ff2_game_last_glow", "1", "If the final mercenary of a team will be highlighted.", _, true, 0.0, true, 1.0);
 	CvarBossSapper = CreateConVar("ff2_boss_sapper", "1", "If sappers can apply a slow on a boss similar to MvM.", _, true, 0.0, true, 1.0);
 	

--- a/addons/sourcemod/scripting/freak_fortress_2/gamemode.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/gamemode.sp
@@ -272,6 +272,13 @@ public Action Gamemode_IntroTimer(Handle timer)
 
 public Action Gamemode_SetControlPoint(Handle timer)
 {
+	if (!CvarEnableCapture.BoolValue)
+	{
+		SetArenaCapEnableTime(0.0);
+		SetControlPoint(false);
+		return Plugin_Handled;
+	}
+	
 	Events_CheckAlivePlayers();
 	
 	PointUnlock = 0;
@@ -958,7 +965,7 @@ void Gamemode_PlayerRunCmd(int client, int buttons)
 			if(PlayersAlive[team] < 3)
 				TF2_AddCondition(client, TF2_GetPlayerClass(client) == TFClass_Scout ? TFCond_Buffed : TFCond_CritCola, 0.5);
 			
-			if(PlayersAlive[team] < 2) 
+			if(PlayersAlive[team] < 2)
 			{
 				TF2_AddCondition(client, TFCond_CritOnDamage, 0.5);
 				if (CvarPlayerGlow.BoolValue)


### PR DESCRIPTION
Adds a convar for enabling the cap point (enabled by default) for servers that want to control if it should turn on or not without messing with the formulas.