### PR TITLE
Fixes bug allowing Red to change to Blu

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2/commands.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/commands.sp
@@ -132,7 +132,7 @@ public Action Command_KermitSewerSlide(int client, const char[] command, int arg
 
 public Action Command_Spectate(int client, const char[] command, int args)
 {
-	if(!Client(client).IsBoss && !Client(client).Minion && (!Enabled || !GameRules_GetProp("m_bInWaitingForPlayers", 1)))
+	if(!Client(client).IsBoss && !Client(client).Minion && (!Enabled || GameRules_GetProp("m_bInWaitingForPlayers", 1)))
 		return Plugin_Continue;
 	
 	return SwapTeam(client, TFTeam_Spectator);
@@ -140,7 +140,7 @@ public Action Command_Spectate(int client, const char[] command, int args)
 
 public Action Command_AutoTeam(int client, const char[] command, int args)
 {
-	if(!Client(client).IsBoss && !Client(client).Minion && (!Enabled || !GameRules_GetProp("m_bInWaitingForPlayers", 1)))
+	if(!Client(client).IsBoss && !Client(client).Minion && (!Enabled || GameRules_GetProp("m_bInWaitingForPlayers", 1)))
 		return Plugin_Continue;
 	
 	int reds, blus;

--- a/addons/sourcemod/scripting/freak_fortress_2/commands.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/commands.sp
@@ -183,7 +183,7 @@ public Action Command_AutoTeam(int client, const char[] command, int args)
 
 public Action Command_JoinTeam(int client, const char[] command, int args)
 {
-	if(!Client(client).IsBoss && !Client(client).Minion && (!Enabled || !GameRules_GetProp("m_bInWaitingForPlayers", 1)))
+	if(!Client(client).IsBoss && !Client(client).Minion && (!Enabled || GameRules_GetProp("m_bInWaitingForPlayers", 1)))
 		return Plugin_Continue;
 	
 	char buffer[10];


### PR DESCRIPTION
This Push fixes two issues:

1) Users were blocked to change to the another team while playing "Waiting for players" round

2) Users were allowed to change to the boss' team while pre-round

This is because a wild `!` lying around