### PR TITLE
Fix for TF2U_GetMaxOverheal() and Attribute sanguise

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2/attributes.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/attributes.sp
@@ -87,22 +87,22 @@ bool Attributes_OnBackstabBoss(int attacker, int victim, float &damage, int weap
 	
 	if(Attributes_FindOnWeapon(attacker, weapon, 217))	// sanguisuge
 	{
-		int maxoverheal = TF2U_GetMaxOverheal(attacker) * 2;	// 250% overheal (from 200% overheal)
+		int maxoverheal = TF2U_GetMaxOverheal(attacker);	// 250% overheal (from 200% overheal)
 		int health = GetClientHealth(attacker);
-		if(health < maxoverheal)
+		if(health < maxoverheal * 2)
 		{
-			SetEntityHealth(attacker, maxoverheal);
-			ApplySelfHealEvent(attacker, maxoverheal - health);
-			
-			if(TF2_IsPlayerInCondition(attacker, TFCond_OnFire))
-				TF2_RemoveCondition(attacker, TFCond_OnFire);
-			
-			if(TF2_IsPlayerInCondition(attacker, TFCond_Bleeding))
-				TF2_RemoveCondition(attacker, TFCond_Bleeding);
-			
-			if(TF2_IsPlayerInCondition(attacker, TFCond_Plague))
-				TF2_RemoveCondition(attacker, TFCond_Plague);
+			SetEntityHealth(attacker, health + maxoverheal);
+			ApplySelfHealEvent(attacker, maxoverheal);
 		}
+		
+		if(TF2_IsPlayerInCondition(attacker, TFCond_OnFire))
+			TF2_RemoveCondition(attacker, TFCond_OnFire);
+			
+		if(TF2_IsPlayerInCondition(attacker, TFCond_Bleeding))
+			TF2_RemoveCondition(attacker, TFCond_Bleeding);
+			
+		if(TF2_IsPlayerInCondition(attacker, TFCond_Plague))
+			TF2_RemoveCondition(attacker, TFCond_Plague);
 	}
 	
 	float value = Attributes_FindOnPlayer(attacker, 296);	// sapper kills collect crits

--- a/addons/sourcemod/scripting/freak_fortress_2/tf2utils.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/tf2utils.sp
@@ -103,10 +103,10 @@ stock int TF2U_GetMaxOverheal(int client)
 	if(Client(client).IsBoss)
 		return Client(client).MaxHealth * Client(client).MaxLives;
 	
-	// 75% overheal from 50%
+	// 100% overheal
 	#if defined __nosoop_tf2_utils_included
 	if(Loaded)
-		return TF2Util_GetPlayerMaxHealthBoost(client, true) / 8 * 6;
+		return TF2Util_GetPlayerMaxHealthBoost(client, true, true);
 	#endif
 	
 	int maxhealth = SDKCall_GetMaxHealth(client);


### PR DESCRIPTION
i should point out that i didn't changed comment lines but Maximum overheal capacity for sanguise is now 260HP for 70HP Spy (+275%)