### PR TITLE
Make FF2R_GetClientScore optional

### DIFF
--- a/addons/sourcemod/scripting/include/ff2r.inc
+++ b/addons/sourcemod/scripting/include/ff2r.inc
@@ -913,6 +913,7 @@ public void __pl_ff2r_SetNTVOptional()
 	MarkNativeAsOptional("FF2R_EmitBossSound");
 	MarkNativeAsOptional("FF2R_GetClientMinion");
 	MarkNativeAsOptional("FF2R_SetClientMinion");
+	MarkNativeAsOptional("FF2R_GetClientScore");
 	MarkNativeAsOptional("FF2R_GetPluginHandle");
 	MarkNativeAsOptional("FF2R_GetGamemodeType");
 	MarkNativeAsOptional("FF2R_StartLagCompensation");


### PR DESCRIPTION
I stumbled on this error.
`[SM] Unable to load plugin "aon\store-common.smx": Native "FF2R_GetClientScore" was not found`

although I have these lines in my plugin
```sp
#undef REQUIRE_PLUGIN
#tryinclude <ff2r>
```
and `FF2R_GetClientScore` in my plugin gets called only if `_ff2r_included` is defined.