### PR TITLE
Fix custom attributes aren't working

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2/weapons.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/weapons.sp
@@ -506,7 +506,7 @@ stock void Weapons_OnHitBossPre(int attacker, int victim, float &damage, int wea
 				kv.GetString("mod attribute hit stale", buffer, sizeof(buffer));
 				if(buffer[0])
 				{
-					char buffers[16][2];
+					char buffers[2][16];
 					ExplodeString(buffer, ";", buffers, sizeof(buffers), sizeof(buffers[]));
 					
 					int attrib = StringToInt(buffers[0]);

--- a/addons/sourcemod/scripting/freak_fortress_2/weapons.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/weapons.sp
@@ -462,7 +462,7 @@ void Weapons_PlayerDeath(int client)
 	HasCritGlow[client] = 0;
 }
 
-stock void Weapons_OnHitBossPre(int attacker, int victim, float &damage, int weapon, int critType, int damagecustom)
+stock void Weapons_OnHitBossPre(int attacker, int victim, float &damage, int weapon, int &critType, int damagecustom)
 {
 	#if defined __tf_custom_attributes_included
 	if(TCALoaded && weapon != -1 && HasEntProp(weapon, Prop_Send, "m_AttributeList"))


### PR DESCRIPTION
Force-A-Nature and Loose Cannon got `ubercharge rate penalty` attribute on each hit because `mod attribute hit stale` has wrong indexes size.
And I fixed a bug where the `critType` was not sending by reference.