### PR TITLE
freak_fortress_2: Fix 'catch_replace' being very broken

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2/bosses.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/bosses.sp
@@ -906,10 +906,6 @@ static void LoadCharacter(const char[] character, int charset, const char[] map,
 											{
 												PrecacheScriptSound(buffer);
 											}
-											
-											Format(buffer2, sizeof(buffer2), "slot%s", key);
-											if(!cfgsub.GetInt(buffer2, length))
-												cfgsub.SetInt(buffer2, 0);
 										}
 										
 										if(music)


### PR DESCRIPTION
Basically only one of the played character sounds from the specified list is getting replaced.
I'm not sure why `ConfigMap.GetInt` returns false here. Maybe this needs further debugging.

From downstream Nec fork.