### PR TITLE
ff2r_menu_abilities: Fix 'weapon' key not working

### DIFF
--- a/addons/sourcemod/scripting/ff2r_menu_abilities.sp
+++ b/addons/sourcemod/scripting/ff2r_menu_abilities.sp
@@ -428,9 +428,9 @@ public bool ShowMenuAll(int client, bool ticked)
 		AbilityData ability = boss.GetAbility(ABILITY_NAME);
 		if(ability)
 		{
-			int var1;
+			int var1 = ability.GetInt("weapon", 0);
 			bool enabled = IsPlayerAlive(client);
-			if(enabled && ability.GetInt("weapon", var1) && var1 >= 0)
+			if(enabled && var1 >= 0)
 			{
 				if(var1 > 9)
 				{
@@ -833,9 +833,9 @@ public int ShowMenuH(Menu menu, MenuAction action, int client, int selection)
 				AbilityData ability = boss.GetAbility(ABILITY_NAME);
 				if(ability)
 				{
-					int var1;
+					int var1 = ability.GetInt("weapon", 0);
 					bool enabled = (!SetupMode[client] && IsPlayerAlive(client));
-					if(enabled && ability.GetInt("weapon", var1) && var1 >= 0)
+					if(enabled && var1 >= 0)
 					{
 						if(var1 > 9)
 						{


### PR DESCRIPTION
Previously only value of `0` for `weapon` keyvalue made the menu appear.
`ability.GetInt("weapon", var1) ` calls `ConfigData.GetInt` which directly returns the value of the keyvalue, not returning it in the `var1` variable, which is used in `ConfigMap.GetInt`

From downstream Nec fork.