### PR TITLE
ff2r_menu_abilities: Fix menu being very broken

### DIFF
--- a/addons/sourcemod/scripting/ff2r_menu_abilities.sp
+++ b/addons/sourcemod/scripting/ff2r_menu_abilities.sp
@@ -649,7 +649,7 @@ public void ShowMenu(int target, int client, BossData boss, AbilityData ability,
 							{
 								length = snap2.KeyBufferSize(a)+1;
 								char[] key2 = new char[length];
-								snap.GetKey(a, key2, length);
+								snap2.GetKey(a, key2, length);
 								
 								float amount;
 								ConfigData mana = cost.GetSection(key2);


### PR DESCRIPTION
**Before** the fix, the abilities were totally unresponsive. On pressing them nothing happens and the menu is ... pretty much useless.

After this fix, ability activation seems to work properly, although there's still like an extra mana being registered for use by abilities...
[Sample picture after fix.](https://steamuserimages-a.akamaihd.net/ugc/2099296363766292016/E2107187694E2E8AA340D46E9AF34E7D09413B4A/?imw=5000&imh=5000&ima=fit&impolicy=Letterbox&imcolor=%23000000&letterbox=false)

So there seems to be another issue here. Maybe it's related to the code on line 255 which is also referencing the wrong variable, however I cannot currently test this theory.

I guess I'll need a recommendation here. 
[Here's the config of the boss](https://paste.ee/p/AtbOR) in case there's issue you can spot if it's config-related issue.

From downstream Nec fork.