### PR TITLE
freak_fortress_2: Fix weapon hiding not working

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2/bosses.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/bosses.sp
@@ -2071,8 +2071,7 @@ static void EquipBoss(int client, bool weapons)
 					}
 					else if(!wearable)
 					{
-						SetEntProp(entity, Prop_Send, "m_iWorldModelIndex", -1);
-						SetEntPropFloat(entity, Prop_Send, "m_flModelScale", 0.001);
+						SetEntityRenderMode(entity, RENDER_ENVIRONMENTAL);
 					}
 					
 					level = 255;


### PR DESCRIPTION
Old weapon hiding code is not working and on top of that changing `m_iWorldModelIndex` results in buggy firstperson animations when M1.

After experiments some time ago at Nec, we found that setting `rendermode` to `RENDER_ENVIRONMENTAL` hides weapon reliably and doesn't cause any other side effects.

From downstream Nec fork.