### PR TITLE
ff2r_default_abilities: Fix crash due to uncached model

### DIFF
--- a/addons/sourcemod/scripting/ff2r_default_abilities.sp
+++ b/addons/sourcemod/scripting/ff2r_default_abilities.sp
@@ -1711,6 +1711,7 @@ public void OnPlayerDeath(Event event, const char[] name, bool dontBroadcast)
 					int entity = CreateEntityByName("prop_physics_override");
 					if(IsValidEntity(entity))
 					{
+						PrecacheModel(model);
 						SetEntityModel(entity, model);
 						SetEntityMoveType(entity, MOVETYPE_VPHYSICS);
 						SetEntProp(entity, Prop_Send, "m_CollisionGroup", 1);


### PR DESCRIPTION
For reference the relevant part of the config of the boss looks like:

```
"special_dropprop"
{
	"model"	"models/weapons/c_models/c_buffalo_steak/c_buffalo_steak.mdl"
	"remove ragdolls"	"1"
	"plugin_name"	"ff2r_default_abilities"
}

"mod_precache"
{
	"models/weapons/c_models/c_buffalo_steak/c_buffalo_steak.mdl" ""
}
```

Even though there's `mod_precache` section, the server still crashes due to this model not being precached.
I guess there's an issue with this section not functioning correctly (yes, I changed map/restarted server, but it won't work), however it won't hurt to preemptively precache the model before use, there won't be significant performance hit, I guess.

From downstream Nec fork.
