### PR TITLE
ff2r_default_abilities: Fix explosive dance remaining after death

### DIFF
--- a/addons/sourcemod/scripting/ff2r_default_abilities.sp
+++ b/addons/sourcemod/scripting/ff2r_default_abilities.sp
@@ -2639,6 +2639,11 @@ public Action Timer_RageExplosiveDance(Handle timer, DataPack pack)
 
 void Rage_ExplosiveDance(int client, ConfigData cfg, const char[] ability, int count)
 {
+	if(!IsPlayerAlive(client))
+	{
+		return;
+	}
+	
 	int alive = GetTotalPlayersAlive(CvarFriendlyFire.BoolValue ? -1 : GetClientTeam(client));
 	float damage = GetFormula(cfg, "damage", alive, 180.0);
 	float distance = GetFormula(cfg, "distance", alive, 350.0);


### PR DESCRIPTION
Scary point of this bug is that explosive dance will follow dead player.