### PR TITLE
ff2r_default_abilities: Fix CBS randomly getting Bat weapon

### DIFF
--- a/addons/sourcemod/scripting/ff2r_default_abilities.sp
+++ b/addons/sourcemod/scripting/ff2r_default_abilities.sp
@@ -1670,7 +1670,7 @@ public void OnPlayerDeath(Event event, const char[] name, bool dontBroadcast)
 					int index = -1;
 					StringMapSnapshot snap = ability.Snapshot();
 					
-					int length = snap.Length;
+					int length = snap.Length - 1;
 					if(length > 0)
 					{
 						int entry = GetURandomInt() % length;


### PR DESCRIPTION
I forgot the exact details of how this fixes the issue.

I guess the logic is if we follow this sample:
```
"special_cbs_multimelee"
{
	// Weapon indexes
	"1"				"171"
	"2"				"193"
	"3"				"232"
	"4"				"401"
	
	"plugin_name"	"ff2r_default_abilities"
}
```
Without the fix `length` will be equal to 5, thus `GetURandomInt()` will return a number in the range 0 to 4 inclusive. But 4 is the index of "plugin_name" (out of range for our situation), so `GetInt()` will return default value of 0.

So decrease length so it's 4 and thus `GetURandomInt()` will return in range 0 to 3. `GetKey()` indexing starts from 0.
You get it.