### PR TITLE
freak_fortress_2: Fix unlocking capture point is not working

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2/gamemode.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/gamemode.sp
@@ -539,7 +539,7 @@ void Gamemode_CheckPointUnlock(int alive, bool notice)
 			}
 		}
 		
-		SetArenaCapEnableTime(0.0);
+		GameRules_SetPropFloat("m_flCapturePointEnableTime", GetGameTime());
 		SetControlPoint(true);
 		PointUnlock = 0;
 	}


### PR DESCRIPTION
In detail:
- tf_logic_arena's `CapEnableDelay` is only used for setting tf_gamerules_data's `m_flCapturePointEnableTime` before arena round start.
- So, unlocking by alive check(`ff2_game_capture_alive`) actually unlock them if `ff2_game_capture_time` ConVar value was not setup(ex. 0.0)
- But if `ff2_game_capture_time` ConVar has positive value, even if the number of people is appropriate, it will not be opened until the time is right.

```
void CTFGameRules::SetupOnStalemateStart( void )
{
...
		CArenaLogic *pArenaLogic = dynamic_cast< CArenaLogic * > (gEntList.FindEntityByClassname( NULL, "tf_logic_arena" ) );

		if ( pArenaLogic )
		{
			pArenaLogic->m_OnArenaRoundStart.FireOutput( pArenaLogic, pArenaLogic );

			if ( tf_arena_override_cap_enable_time.GetFloat() > 0 )
			{
				m_flCapturePointEnableTime = gpGlobals->curtime + tf_arena_override_cap_enable_time.GetFloat();
			}
			else
			{
				m_flCapturePointEnableTime = gpGlobals->curtime + pArenaLogic->m_flTimeToEnableCapPoint;
			}

			IGameEvent *event = gameeventmanager->CreateEvent( "arena_round_start" );
			if ( event )
			{
				gameeventmanager->FireEvent( event );
			}

			BroadcastSound( 255, "Announcer.AM_RoundStartRandom" );
		}
...
}
```