### PR TITLE
Fix strip on wearable

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2/weapons.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/weapons.sp
@@ -793,7 +793,18 @@ public void Weapons_SpawnFrame(int ref)
 	
 	bool found;
 	if(cfg.GetBool("strip", found, false) && found)
-		DHook_HookStripWeapon(entity);
+	{
+		char classname[36];
+		GetEntityClassname(entity, classname, sizeof(classname));
+		if(!StrContains(classname, "tf_wearable"))
+		{
+			SetEntProp(entity, Prop_Send, "m_bOnlyIterateItemViewAttributes", true);
+		}
+		else
+		{
+			DHook_HookStripWeapon(entity);
+		}
+	}
 	
 	int current;
 	


### PR DESCRIPTION
- Wearable like `tf_wearable_demo_shield` cannot stripped by current method.
- So set `m_bOnlyIterateItemViewAttributes` to true instead. There won't be any problem using this method for wearable.

Using ff2r's strip option(Attributes mean `dmg taken from fire reduced` and `dmg taken from blast reduced`)
![image](https://github.com/Batfoxkid/Freak-Fortress-2-Rewrite/assets/96904513/5a6687d5-f152-41b1-88f2-28bd5543be74)

Using cwx's `keep_static_attrs`(strip) option(It use `m_bOnlyIterateItemViewAttributes`)
![image](https://github.com/Batfoxkid/Freak-Fortress-2-Rewrite/assets/96904513/028ced61-f36f-4916-a038-0fb258a0ec11)
