### PR TITLE
Fix switching to previous weapon not working correctly

### DIFF
--- a/addons/sourcemod/scripting/ff2r_default_abilities.sp
+++ b/addons/sourcemod/scripting/ff2r_default_abilities.sp
@@ -2526,19 +2526,30 @@ public Action Timer_RemoveItem(Handle timer, DataPack pack)
 					static int length;
 					if(!length)
 						length = GetEntPropArraySize(client, Prop_Send, "m_hMyWeapons");
-					
-					char classname[36];
+
 					for(int i; i < length; i++)
 					{
 						int other = GetEntPropEnt(client, Prop_Send, "m_hMyWeapons", i);
-						if(other != entity && GetEntityClassname(other, classname, sizeof(classname)))
+						if(other != entity)
 						{
-							FakeClientCommand(client, "use %s", classname);
+							if(HasEntProp(entity, Prop_Send, "m_iWeaponState")) //Reset minigun-like weapons
+							{
+								SetEntProp(entity, Prop_Send, "m_iWeaponState", 0);
+								TF2_RemoveCondition(client, TFCond_Slowed);
+							}
+
+							#if defined __nosoop_tf2_utils_included
+							if(TF2ULoaded)
+							{
+								TF2Util_SetPlayerActiveWeapon(client, other);
+							}
+							#endif
+							SetEntPropEnt(client, Prop_Send, "m_hActiveWeapon", other);
 							break;
 						}
 					}
 				}
-				
+
 				TF2_RemoveItem(client, entity);
 			}
 		}


### PR DESCRIPTION
Fixes:
* Sometimes weapon switching doesn't happen (`use %s` doesn't always permit that)
* Switching from minigun while revved up causing slowdown

Code calls `SetEntPropEnt(client, Prop_Send, "m_hActiveWeapon", other);` all the time, since `TF2Util_SetPlayerActiveWeapon` may not switch weapons sometimes, so it acts as a fallback. At least
`TF2Util_SetPlayerActiveWeapon` always calls the necessary weapon switching hooks (so I guess it works similar to `use %s`, without needing classnames and other overheads applied).

This should fix https://github.com/Batfoxkid/Freak-Fortress-2-Rewrite/issues/141