### PR TITLE
Setting m_iBlastJumpState on superjump

### DIFF
--- a/addons/sourcemod/gamedata/ff2.txt
+++ b/addons/sourcemod/gamedata/ff2.txt
@@ -173,6 +173,11 @@
 				"linux"		"3512"
 				"windows"	"3512"
 			}
+			"CTFPlayer::m_iBlastJumpState"
+			{
+				"linux"		"8584"
+				"windows"	"8584"
+			}
 		}
 		"Functions"
 		{


### PR DESCRIPTION
I found a bug that minicrit doesn't applied with `mod mini-crit airborne` on super-jumping boss.
The reason for that was discovered after the decompiling latest server.so.

```
bool CTFGameRules::ApplyOnDamageModifyRules() {
...
	int iMiniCritAirborne = 0;
	CALL_ATTRIB_HOOK_INT_ON_OTHER( pWeapon, iMiniCritAirborne, mini_crit_airborne );
	if ( iMiniCritAirborne == 1 && pVictim && ( ( !(GetFlags() & FL_ONGROUND) && (GetWaterLevel() == WL_NotInWater) && (m_iBlastJumpState != 0) ) || pVictim->m_Shared.InCond( TF_COND_KNOCKED_INTO_AIR ) ) )
	{
		bAllSeeCrit = true;
		info.SetCritType( CTakeDamageInfo::CRIT_MINI );
		eBonusEffect = kBonusEffect_MiniCrit;
		break;
	}
...
}
```
Other attributes related to blast-jumping such as `rocketjump attackrate bonus` only check `TFCond_BlastJumping`.
But `mod mini-crit airborne` check `m_iBlastJumpState` or `TFCond_KnockedIntoAir`.

I chose setting `m_iBlastJumpState` because giving `TFCond_KnockedIntoAir` could cause problems for a double donk or a scorched shot. So, I got a offset of `m_iBlastJumpState` to do that.
```
Step of getting offset of "m_iBlastJumpState" if it changed.
NOTE: window offset is same as linux one
1. find "CTFPlayer::SetBlastJumpState"(It contains unique xref to string `sticky_jump` and `rocket_jump` for event)
2. decompile it
3. First bitwise OR operation is `m_iBlastJumpState`.
```
and I used `TF_PLAYER_ENEMY_BLASTED_ME` because other flags can make event likes `rocket_jump_landed` or `sticky_jump_landed`.