### PR TITLE
Do exact boss name matching in OnSpecialSelected

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2/forwards_old.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/forwards_old.sp
@@ -171,7 +171,7 @@ void ForwardOld_OnSpecialSelected(int boss, int &special, bool preset)
 	{
 		if(name[0])
 		{
-			special2 = Bosses_GetByName(name, false);
+			special2 = Bosses_GetByName(name, true);
 			if(special2 != -1)
 				special = special2;
 		}


### PR DESCRIPTION
The story:
We use hidden spawning plugin which spawns hidden bosses randomly, the plugin was made for FF2Bat. When one of the hidden bosses spawns, `characterName` was set to for example `hiddens/supremex10` (aka the path to the boss config) and everything worked fine.

The same plugin was tested on FF2R and It didn't work correctly, hidden boss will randomly not get forced. It seems FF2R only checks the `name` of the boss. Ok, then. I modified the plugin to set `characterName` to exact boss name. Tested and it also didn't work all the time. Fine. More code checking and it seems `OnSpecialSelected` uses inexact boss name matching. So I switched second argument to `true`

So there's the pull request, do exact boss name checking in `OnSpecialSelected`.

