### PR TITLE
Fix crit type limit

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2/attributes.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/attributes.sp
@@ -228,7 +228,7 @@ void Attributes_OnHitBossPre(int attacker, int victim, int &damagetype, int weap
 		}
 	}
 	
-	if(!critType && ((TF2_IsPlayerInCondition(attacker, TFCond_BlastJumping) && Attributes_FindOnWeapon(attacker, weapon, 621)) ||	// rocketjump attackrate bonus
+	if((!critType && !(damagetype & DMG_CRIT)) && ((TF2_IsPlayerInCondition(attacker, TFCond_BlastJumping) && Attributes_FindOnWeapon(attacker, weapon, 621)) ||	// rocketjump attackrate bonus
 	   (TF2_IsPlayerInCondition(attacker, TFCond_DisguiseRemoved) && Attributes_FindOnWeapon(attacker, weapon, 410)))) 	// damage bonus while disguised
 	{
 		critType = 1;

--- a/addons/sourcemod/scripting/freak_fortress_2/weapons.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/weapons.sp
@@ -500,7 +500,7 @@ stock void Weapons_OnHitBossPre(int attacker, int victim, float &damage, int wea
 				Gamemode_SetClientGlow(victim, value);
 			}
 			
-			if(critType != 2)
+			if(critType != 2 && !(damagetype & DMG_CRIT))
 				critType = kv.GetNum("mod crit type on bosses", critType);
 			
 			value = kv.GetFloat("multi boss rage", 1.0);


### PR DESCRIPTION
Known Bugs:
- Minicrit gained by `mod crit type on bosses` override normal critical(ex. headshot, flare).
- Air strike's projectile deal minicrit while rocket jump even if crit-boosted.

Fix:
- In `CTFGameRules::ApplyOnDamageModifyRules`, if damage type has `DMG_CRIT`, critType will change to 2(Crit_Full).
- In FF2R, if `OnTakeDamage` library doesn't exist, check damage type is DMG_CRIT. But library exist, only check critType.
- But most situation need to check damage type. Because critType will be determined in `CTFGameRules::ApplyOnDamageModifyRules`.
- So I added damage type check.

- Still attribute 410 is not fixed..

This should fix #138.