### PR TITLE
Fixed wrong classname in GetClassWeaponClassname

### DIFF
--- a/addons/sourcemod/scripting/ff2r_default_abilities.sp
+++ b/addons/sourcemod/scripting/ff2r_default_abilities.sp
@@ -3469,15 +3469,14 @@ void GetClassWeaponClassname(TFClassType class, char[] name, int length)
 	{ 
 		switch(class)
 		{
-			case TFClass_Scout:	strcopy(name, length, "tf_weapon_bat");
-			case TFClass_Pyro:	strcopy(name, length, "tf_weapon_fireaxe");
-			case TFClass_DemoMan:	strcopy(name, length, "tf_weapon_bottle");
-			case TFClass_Heavy:	strcopy(name, length, "tf_weapon_fists");
-			case TFClass_Engineer:	strcopy(name, length, "tf_weapon_wrench");
-			case TFClass_Medic:	strcopy(name, length, "tf_weapon_bonesaw");
-			case TFClass_Sniper:	strcopy(name, length, "tf_weapon_club");
-			case TFClass_Spy:	strcopy(name, length, "tf_weapon_knife");
-			default:		strcopy(name, length, "tf_weapon_shovel");
+			case TFClass_Scout:			strcopy(name, length, "tf_weapon_bat");
+			case TFClass_Pyro, TFClass_Heavy:	strcopy(name, length, "tf_weapon_fireaxe");
+			case TFClass_DemoMan:			strcopy(name, length, "tf_weapon_bottle");
+			case TFClass_Engineer:			strcopy(name, length, "tf_weapon_wrench");
+			case TFClass_Medic:			strcopy(name, length, "tf_weapon_bonesaw");
+			case TFClass_Sniper:			strcopy(name, length, "tf_weapon_club");
+			case TFClass_Spy:			strcopy(name, length, "tf_weapon_knife");
+			default:				strcopy(name, length, "tf_weapon_shovel");
 		}
 	}
 	else if(StrEqual(name, "tf_weapon_shotgun"))

--- a/addons/sourcemod/scripting/freak_fortress_2/stocks.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/stocks.sp
@@ -110,15 +110,14 @@ void GetClassWeaponClassname(TFClassType class, char[] name, int length)
 	{ 
 		switch(class)
 		{
-			case TFClass_Scout:	strcopy(name, length, "tf_weapon_bat");
-			case TFClass_Pyro:	strcopy(name, length, "tf_weapon_fireaxe");
-			case TFClass_DemoMan:	strcopy(name, length, "tf_weapon_bottle");
-			case TFClass_Heavy:	strcopy(name, length, "tf_weapon_fists");
-			case TFClass_Engineer:	strcopy(name, length, "tf_weapon_wrench");
-			case TFClass_Medic:	strcopy(name, length, "tf_weapon_bonesaw");
-			case TFClass_Sniper:	strcopy(name, length, "tf_weapon_club");
-			case TFClass_Spy:	strcopy(name, length, "tf_weapon_knife");
-			default:		strcopy(name, length, "tf_weapon_shovel");
+			case TFClass_Scout:			strcopy(name, length, "tf_weapon_bat");
+			case TFClass_Pyro, TFClass_Heavy:	strcopy(name, length, "tf_weapon_fireaxe");
+			case TFClass_DemoMan:			strcopy(name, length, "tf_weapon_bottle");
+			case TFClass_Engineer:			strcopy(name, length, "tf_weapon_wrench");
+			case TFClass_Medic:			strcopy(name, length, "tf_weapon_bonesaw");
+			case TFClass_Sniper:			strcopy(name, length, "tf_weapon_club");
+			case TFClass_Spy:			strcopy(name, length, "tf_weapon_knife");
+			default:				strcopy(name, length, "tf_weapon_shovel");
 		}
 	}
 	else if(StrEqual(name, "tf_weapon_shotgun"))


### PR DESCRIPTION
## Description
In decomplied `TranslateWeaponEntForClass` and `pszWpnEntTranslationList`,
```
.data:01787510                 dd offset aSaxxy        ; "saxxy"
.data:01787514                 dd offset unk_140F41A - TFClass_Unknown
.data:01787518                 dd offset aTfWeaponBat  ; "tf_weapon_bat" - TFClass_Scout
.data:0178751C                 dd offset aTfWeaponClub ; "tf_weapon_club" - TFClass_Sniper
.data:01787520                 dd offset aTfWeaponShovel ; "tf_weapon_shovel" - TFClass_Soldier
.data:01787524                 dd offset aTfWeaponBottle ; "tf_weapon_bottle" - TFClass_Demoman
.data:01787528                 dd offset aTfWeaponBonesa ; "tf_weapon_bonesaw" - TFClass_Medic
.data:0178752C                 dd offset aTfWeaponFireax ; "tf_weapon_fireaxe" - TFClass_Heavy
.data:01787530                 dd offset aTfWeaponFireax ; "tf_weapon_fireaxe" - TFClass_Pyro
.data:01787534                 dd offset aTfWeaponKnife ; "tf_weapon_knife" - TFClass_Spy
.data:01787538                 dd offset aTfWeaponWrench ; "tf_weapon_wrench" - TFClass_Engineer
```
If the class is heavy, return it to "tf_weapon_fireaxe" instead of "tf_weapon_fists". I don't know when it changed.
## Additional Image
![image](https://github.com/Batfoxkid/Freak-Fortress-2-Rewrite/assets/96904513/83a56cb2-2beb-4e49-a320-202df72139fa)
![image](https://github.com/Batfoxkid/Freak-Fortress-2-Rewrite/assets/96904513/2da8181f-1eae-4bfb-b30d-87af715c7028)