### PR TITLE
freak_fortress_2: Fix waitingforplayer phase skipping

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2/gamemode.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/gamemode.sp
@@ -120,15 +120,7 @@ void Gamemode_MapInit()
 void Gamemode_MapStart()
 {
 	RoundStatus = -1;
-	Waiting = true;
-	for(int i = 1; i <= MaxClients; i++)
-	{
-		if(IsClientInGame(i))
-		{
-			Waiting = false;
-			break;
-		}
-	}
+	Waiting = GameRules_GetRoundState() < RoundState_StartGame;
 }
 
 void Gamemode_MapEnd()


### PR DESCRIPTION
- "Can't joining any team" issue was fixed on Various Fixes. But gamemode.sp still use old detect method. As a result, it skips "waiting for player" phase.