### PR TITLE
freak_fortress_2: Fix dropping `item_healthkit_small`

### DIFF
--- a/addons/sourcemod/gamedata/ff2.txt
+++ b/addons/sourcemod/gamedata/ff2.txt
@@ -110,6 +110,12 @@
 				"linux"		"@_ZN16CTFWeaponBuilder13StartBuildingEv"
 				"windows"	"\x55\x8B\xEC\x51\x8B\xD1\x53\x89\x55\xFC"
 			}
+			"CTFPowerup::DropSingleInstance"
+			{
+				"library"	"server"
+				"linux"		"@_ZN10CTFPowerup18DropSingleInstanceER6VectorP20CBaseCombatCharacterff"
+				"windows"	"\x55\x8B\xEC\x53\x56\x57\x6A\x01"
+			}
 		}
 		"Offsets"
 		{

--- a/addons/sourcemod/scripting/freak_fortress_2/attributes.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/attributes.sp
@@ -272,7 +272,7 @@ void Attributes_OnHitBoss(int attacker, int victim, int inflictor, float fdamage
 			position[2] += 20.0;
 			
 			float velocity[3];
-			velocity[2] = 50.0;
+			velocity[2] = 75.0;
 			
 			int team = GetClientTeam(attacker);  
 			for(int i; i < amount; i++)
@@ -283,11 +283,10 @@ void Attributes_OnHitBoss(int attacker, int victim, int inflictor, float fdamage
 					DispatchKeyValue(entity, "OnPlayerTouch", "!self,Kill,,0,-1");
 					DispatchSpawn(entity);
 					SetEntProp(entity, Prop_Send, "m_iTeamNum", team);
-					SetEntityMoveType(entity, MOVETYPE_VPHYSICS);
-					velocity[0] = GetRandomFloat(-10.0, 10.0);
-					velocity[1] = GetRandomFloat(-10.0, 10.0);
-					TeleportEntity(entity, position, _, velocity);
-					SetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity", attacker);
+					TeleportEntity(entity, position);
+					velocity[0] = GetRandomFloat(-75.0, 75.0);
+					velocity[1] = GetRandomFloat(-75.0, 75.0);
+					SDKCall_DropSingleInstance(entity, velocity, attacker, 0.1);
 				}
 			}
 		}

--- a/addons/sourcemod/scripting/freak_fortress_2/sdkcalls.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/sdkcalls.sp
@@ -6,6 +6,7 @@
 	bool SDKCall_CheckBlockBackstab(int client, int attacker)
 	void SDKCall_SetSpeed(int client)
 	void SDKCall_ChangeClientTeam(int client, int newTeam)
+	void SDKCall_DropSingleInstance(int entity, const float velocity[3], int thrower, float throwerTouchDelay, float resetTime = 0.0)
 */
 
 #pragma semicolon 1
@@ -21,6 +22,7 @@ static Handle SDKTeamRemovePlayer;
 static Handle SDKIncrementStat;
 static Handle SDKCheckBlockBackstab;
 static Handle SDKSetSpeed;
+static Handle SDKDropSingleInstance;
 
 void SDKCall_Setup()
 {
@@ -105,6 +107,16 @@ void SDKCall_Setup()
 	SDKSetSpeed = EndPrepSDKCall();
 	if(!SDKSetSpeed)
 		LogError("[Gamedata] Could not find CTFPlayer::TeamFortress_SetSpeed");
+	
+	StartPrepSDKCall(SDKCall_Entity);
+	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CTFPowerup::DropSingleInstance");
+	PrepSDKCall_AddParameter(SDKType_Vector, SDKPass_ByRef);
+	PrepSDKCall_AddParameter(SDKType_CBaseEntity, SDKPass_Pointer);
+	PrepSDKCall_AddParameter(SDKType_Float, SDKPass_ByValue);
+	PrepSDKCall_AddParameter(SDKType_Float, SDKPass_ByValue);
+	SDKDropSingleInstance = EndPrepSDKCall();
+	if(!SDKDropSingleInstance)
+		LogError("[Gamedata] Could not find CTFPowerup::DropSingleInstance");
 	
 	delete gamedata;
 }
@@ -226,5 +238,12 @@ void SDKCall_ChangeClientTeam(int client, int newTeam)
 		{
 			TF2Attrib_SetByDefIndex(client, 406, 4.0);
 		}
+	}
+}
+
+void SDKCall_DropSingleInstance(int entity, const float velocity[3], int thrower, float throwerTouchDelay, float resetTime = 0.0) {
+	if(SDKDropSingleInstance)
+	{
+		SDKCall(SDKDropSingleInstance, entity, velocity, thrower, throwerTouchDelay, resetTime);
 	}
 }


### PR DESCRIPTION
- Increased velocity to proper dispersal of medikit(too low to spread).
- I used `CTFPowerup::DropSingleInstance`. It's not good to chase game updates with functions.
- `CTFPowerup::DropSingleInstance` has unique x-ref string `"PowerupRemoveThink"`.

Fixes #168.