### PR TITLE
ff2r_default_abilities: Add 'rival' to specify whether minion will respawn on rival team

### DIFF
--- a/addons/sourcemod/scripting/ff2r_default_abilities.sp
+++ b/addons/sourcemod/scripting/ff2r_default_abilities.sp
@@ -5,6 +5,7 @@
 		"amount"			"n/3 + 1"	// Amount of clones to summon
 		"die on boss death"	"true"		// If clones die when the boss dies
 		"allow bosses"	"false"		//Allow bosses to become minions (in the process the boss becomes normal player)
+		"rival"		"false"		//Whether players will spawn on ally or rival team
 		
 		"character"
 		{
@@ -2604,6 +2605,7 @@ void Rage_CloneAttack(int client, ConfigData cfg)
 		
 		int owner = cfg.GetBool("die on boss death", true) ? client : -1;
 		bool allowBosses = cfg.GetBool("allow bosses", false);
+		bool rival = cfg.GetBool("rival", false);
 
 		ConfigData minion = cfg.GetSection("character");
 		
@@ -2629,7 +2631,7 @@ void Rage_CloneAttack(int client, ConfigData cfg)
 			}
 			
 			if(victims)
-				SpawnCloneList(victim, victims, amount, minion, owner, team, pos);
+				SpawnCloneList(victim, victims, amount, minion, owner, team, pos, rival);
 		}
 		
 		if(amount)
@@ -2652,7 +2654,7 @@ void Rage_CloneAttack(int client, ConfigData cfg)
 			}
 			
 			if(victims)
-				SpawnCloneList(victim, victims, amount, minion, owner, team, pos);
+				SpawnCloneList(victim, victims, amount, minion, owner, team, pos, rival);
 			
 			if(amount)
 			{
@@ -2674,13 +2676,13 @@ void Rage_CloneAttack(int client, ConfigData cfg)
 				}
 				
 				if(victims)
-					SpawnCloneList(victim, victims, amount, minion, owner, team, pos);
+					SpawnCloneList(victim, victims, amount, minion, owner, team, pos, rival);
 			}
 		}
 	}
 }
 
-void SpawnCloneList(int[] clients, int &amount, int &cap, ConfigData cfg, int owner, int team, const float pos[3])
+void SpawnCloneList(int[] clients, int &amount, int &cap, ConfigData cfg, int owner, int team, const float pos[3], bool rivalTeam)
 {
 	if(amount > cap)
 	{
@@ -2697,6 +2699,9 @@ void SpawnCloneList(int[] clients, int &amount, int &cap, ConfigData cfg, int ow
 		
 		if(IsPlayerAlive(clients[i]))
 			ForcePlayerSuicide(clients[i]);
+
+		if(rivalTeam)
+			team = (team == 2) ? 3 : 2;
 		
 		if(cfg)
 			FF2R_CreateBoss(clients[i], cfg, team);


### PR DESCRIPTION
There'll be a followup PR which will specify whether minions will spawn in spawn or not.