### PR TITLE
File Network for Boss Downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Recommended:
 Supported:
 
 - [SteamWorks](https://github.com/ExperimentFailed/SteamWorks)
+- [File Network](https://github.com/Batfoxkid/File-Network)
 - [SM-TFUtils](https://github.com/nosoop/SM-TFUtils)
 - [SM-TFCustomWeaponsX](https://github.com/nosoop/SM-TFCustomWeaponsX)
 - [Goomba](https://github.com/Flyflo/SM-Goomba-Stomp-Addons)

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -126,7 +126,8 @@ enum SectionType
 	Section_Precache,	// precache
 	Section_Download,	// download
 	Section_Model,		// mod_download
-	Section_Material	// mat_download
+	Section_Material,	// mat_download
+	Section_FileNet		// filenetwork
 };
 
 enum struct SoundEnum
@@ -138,6 +139,7 @@ enum struct SoundEnum
 	
 	char Overlay[PLATFORM_MAX_PATH];
 	float Duration;
+	int OverlayFileNet;
 	
 	int Entity;
 	int Channel;
@@ -145,6 +147,8 @@ enum struct SoundEnum
 	int Flags;
 	float Volume;
 	int Pitch;
+
+	int FileNet;
 	
 	void Default()
 	{
@@ -236,6 +240,7 @@ Handle ThisPlugin;
 #include "freak_fortress_2/dhooks.sp"
 #include "freak_fortress_2/econdata.sp"
 #include "freak_fortress_2/events.sp"
+#include "freak_fortress_2/filenetwork.sp"
 #include "freak_fortress_2/formula_parser.sp"
 #include "freak_fortress_2/forwards.sp"
 #include "freak_fortress_2/forwards_old.sp"
@@ -297,6 +302,7 @@ public void OnPluginStart()
 	Database_PluginStart();
 	DHook_Setup();
 	Events_PluginStart();
+	FileNet_PluginStart();
 	Gamemode_PluginStart();
 	Menu_PluginStart();
 	Music_PluginStart();
@@ -354,6 +360,7 @@ public void OnConfigsExecuted()
 public void OnMapEnd()
 {
 	Bosses_MapEnd();
+	FileNet_MapEnd();
 	Gamemode_MapEnd();
 	Preference_MapEnd();
 }
@@ -370,6 +377,7 @@ public void OnPluginEnd()
 
 public void OnLibraryAdded(const char[] name)
 {
+	FileNet_LibraryAdded(name);
 	SDKHook_LibraryAdded(name);
 	SteamWorks_LibraryAdded(name);
 	TF2U_LibraryAdded(name);
@@ -379,6 +387,7 @@ public void OnLibraryAdded(const char[] name)
 
 public void OnLibraryRemoved(const char[] name)
 {
+	FileNet_LibraryRemoved(name);
 	SDKHook_LibraryRemoved(name);
 	SteamWorks_LibraryRemoved(name);
 	TF2U_LibraryRemoved(name);
@@ -389,6 +398,7 @@ public void OnLibraryRemoved(const char[] name)
 public void OnClientPutInServer(int client)
 {
 	DHook_HookClient(client);
+	FileNet_ClientPutInServer(client);
 	SDKHook_HookClient(client);
 }
 
@@ -402,6 +412,7 @@ public void OnClientDisconnect(int client)
 	Bosses_ClientDisconnect(client);
 	Database_ClientDisconnect(client);
 	Events_CheckAlivePlayers(client);
+	FileNet_ClientDisconnect(client);
 	Preference_ClientDisconnect(client);
 	
 	Client(client).ResetByAll();

--- a/addons/sourcemod/scripting/freak_fortress_2/attributes.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/attributes.sp
@@ -21,7 +21,7 @@ void Attributes_PluginStart()
 	HookUserMessage(GetUserMessageId("PlayerJarated"), Attributes_OnJarateBoss);
 }
 
-public Action Attributes_OnJarateBoss(UserMsg msg_id, BfRead bf, const int[] players, int playersNum, bool reliable, bool init)
+static Action Attributes_OnJarateBoss(UserMsg msg_id, BfRead bf, const int[] players, int playersNum, bool reliable, bool init)
 {
 	int attacker = bf.ReadByte();
 	int victim = bf.ReadByte();
@@ -63,7 +63,7 @@ public Action Attributes_OnJarateBoss(UserMsg msg_id, BfRead bf, const int[] pla
 	return Plugin_Continue;
 }
 
-public void ReapplyMilk(DataPack pack)
+static void ReapplyMilk(DataPack pack)
 {
 	pack.Reset();
 	
@@ -183,7 +183,7 @@ bool Attributes_OnBackstabBoss(int attacker, int victim, float &damage, int weap
 	return silent;
 }
 
-public void Attributes_RedisguiseFrame(DataPack pack)
+static void Attributes_RedisguiseFrame(DataPack pack)
 {
 	pack.Reset();
 
@@ -756,7 +756,7 @@ bool Attributes_GetByDefIndex(int entity, int index, float &value)
 	return false;
 }
 
-public Action Attributes_BoostDrainStack(Handle timer, DataPack pack)
+static Action Attributes_BoostDrainStack(Handle timer, DataPack pack)
 {
 	pack.Reset();
 	int client = GetClientOfUserId(pack.ReadCell());

--- a/addons/sourcemod/scripting/freak_fortress_2/commands.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/commands.sp
@@ -30,7 +30,7 @@ void Command_PluginStart()
 	AddCommandListener(Command_EurekaTeleport, "eureka_teleport");
 }
 
-public bool FF2TargetFilter(const char[] pattern, ArrayList clients)
+static bool FF2TargetFilter(const char[] pattern, ArrayList clients)
 {
 	FF2FilterSearch filterSearch = StrContains(pattern, "minion", true) != -1 ? FF2FilterSearch_Minion : FF2FilterSearch_Boss;
 	bool isOppositeFilter = pattern[1] == '!';
@@ -78,7 +78,7 @@ public bool FF2TargetFilter(const char[] pattern, ArrayList clients)
 	return true;
 }
 
-public Action Command_Voicemenu(int client, const char[] command, int args)
+static Action Command_Voicemenu(int client, const char[] command, int args)
 {
 	if(client && args == 2 && Client(client).IsBoss && IsPlayerAlive(client) && (!Enabled || RoundStatus == 1))
 	{
@@ -121,7 +121,7 @@ public Action Command_Voicemenu(int client, const char[] command, int args)
 	return Plugin_Continue;
 }
 
-public Action Command_KermitSewerSlide(int client, const char[] command, int args)
+static Action Command_KermitSewerSlide(int client, const char[] command, int args)
 {
 	if(Enabled)
 	{
@@ -131,7 +131,7 @@ public Action Command_KermitSewerSlide(int client, const char[] command, int arg
 	return Plugin_Continue;
 }
 
-public Action Command_Spectate(int client, const char[] command, int args)
+static Action Command_Spectate(int client, const char[] command, int args)
 {
 	if((!Client(client).IsBoss && !Client(client).Minion && (!Enabled || GameRules_GetProp("m_bInWaitingForPlayers", 1))) || IsEmptyServer())
 		return Plugin_Continue;
@@ -139,7 +139,7 @@ public Action Command_Spectate(int client, const char[] command, int args)
 	return SwapTeam(client, TFTeam_Spectator);
 }
 
-public Action Command_AutoTeam(int client, const char[] command, int args)
+static Action Command_AutoTeam(int client, const char[] command, int args)
 {
 	if((!Client(client).IsBoss && !Client(client).Minion && (!Enabled || GameRules_GetProp("m_bInWaitingForPlayers", 1))) || IsEmptyServer())
 		return Plugin_Continue;
@@ -182,7 +182,7 @@ public Action Command_AutoTeam(int client, const char[] command, int args)
 	return SwapTeam(client, team);
 }
 
-public Action Command_JoinTeam(int client, const char[] command, int args)
+static Action Command_JoinTeam(int client, const char[] command, int args)
 {
 	if((!Client(client).IsBoss && !Client(client).Minion && (!Enabled || GameRules_GetProp("m_bInWaitingForPlayers", 1))) || IsEmptyServer())
 		return Plugin_Continue;
@@ -285,7 +285,7 @@ static Action SwapTeam(int client, int wantTeam)
 	return Plugin_Continue;
 }
 
-public Action Command_AggressiveSwap(Handle timer, DataPack pack)
+static Action Command_AggressiveSwap(Handle timer, DataPack pack)
 {
 	pack.Reset();
 	int client = GetClientOfUserId(pack.ReadCell());
@@ -301,7 +301,7 @@ public Action Command_AggressiveSwap(Handle timer, DataPack pack)
 	return Plugin_Stop;
 }
 
-public Action Command_JoinClass(int client, const char[] command, int args)
+static Action Command_JoinClass(int client, const char[] command, int args)
 {
 	if(Client(client).IsBoss || Client(client).Minion)
 	{
@@ -324,7 +324,7 @@ public Action Command_JoinClass(int client, const char[] command, int args)
 	return Plugin_Continue;
 }
 
-public Action Command_EurekaTeleport(int client, const char[] command, int args)
+static Action Command_EurekaTeleport(int client, const char[] command, int args)
 {
 	if(Enabled && RoundStatus == 1 && IsPlayerAlive(client))
 	{

--- a/addons/sourcemod/scripting/freak_fortress_2/configs.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/configs.sp
@@ -152,7 +152,7 @@ bool Configs_SetMap(const char[] mapname)
 	return true;
 }
 
-public void Configs_StartVote(ConVar cvar, const char[] oldValue, const char[] newValue)
+static void Configs_StartVote(ConVar cvar, const char[] oldValue, const char[] newValue)
 {
 	if(!VotedPack && Cvar[PackVotes].BoolValue && Bosses_GetCharsetLength() > 1 && Configs_MapIsGamemode(newValue))
 	{
@@ -161,13 +161,13 @@ public void Configs_StartVote(ConVar cvar, const char[] oldValue, const char[] n
 	}
 }
 
-public Action Configs_PackVote(Handle timer)
+static Action Configs_PackVote(Handle timer)
 {
 	Configs_PackVoteFrame();
 	return Plugin_Continue;
 }
 
-public void Configs_PackVoteFrame()
+static void Configs_PackVoteFrame()
 {
 	if(IsVoteInProgress())
 	{
@@ -211,7 +211,7 @@ public void Configs_PackVoteFrame()
 	}
 }
 
-public int Configs_PackVoteH(Menu menu, MenuAction action, int param1, int param2)
+static int Configs_PackVoteH(Menu menu, MenuAction action, int param1, int param2)
 {
 	switch(action)
 	{

--- a/addons/sourcemod/scripting/freak_fortress_2/convars.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/convars.sp
@@ -182,18 +182,6 @@ static void ConVar_Add(const char[] name, const char[] value, bool enforce = tru
 	CvarList.PushArray(info);
 }
 
-public void ConVar_OnlyChangeOnEmpty(ConVar cvar, const char[] oldValue, const char[] newValue)
-{
-	for(int client = 1; client <= MaxClients; client++)
-	{
-		if(IsClientInGame(client))
-		{
-			cvar.SetString(oldValue);
-			break;
-		}
-	}
-}
-
 stock void ConVar_Remove(const char[] name)
 {
 	ConVar cvar = FindConVar(name);
@@ -263,7 +251,7 @@ void ConVar_Disable()
 	}
 }
 
-public void ConVar_OnChanged(ConVar cvar, const char[] oldValue, const char[] newValue)
+static void ConVar_OnChanged(ConVar cvar, const char[] oldValue, const char[] newValue)
 {
 	int index = CvarList.FindValue(cvar, CvarInfo::cvar);
 	if(index != -1)

--- a/addons/sourcemod/scripting/freak_fortress_2/convars.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/convars.sp
@@ -49,7 +49,7 @@ void ConVar_PluginStart()
 	Cvar[SubpluginFolder] = CreateConVar("ff2_plugin_subplugins", "freaks", "Folder to load/unload when bosses are at play relative to the plugins folder.");
 	Cvar[FileCheck] = CreateConVar("ff2_plugin_checkfiles", "1", "If to check and warn about missing files from bosses. (Disabling this can help load times.)", _, true, 0.0, true, 1.0);
 	Cvar[PackVotes] = CreateConVar("ff2_plugin_packvotes", "1", "If to host a boss pack vote when the next map is set.", _, true, 0.0, true, 1.0);
-	Cvar[StreakDamage] = CreateConVar("ff2_game_streakdamage", "400", "Amount of damage against a boss to display as a kill.", _, true, 0.0, true, 1.0);
+	Cvar[StreakDamage] = CreateConVar("ff2_game_streakdamage", "400", "Amount of damage against a boss to display as a kill.", _, true, 1.0);
 	
 	CreateConVar("ff2_oldjump", "1", "Backwards Compatibility ConVar", FCVAR_DONTRECORD|FCVAR_HIDDEN, true, 0.0, true, 1.0);
 	CreateConVar("ff2_base_jumper_stun", "0", "Backwards Compatibility ConVar", FCVAR_DONTRECORD|FCVAR_HIDDEN, true, 0.0, true, 1.0);

--- a/addons/sourcemod/scripting/freak_fortress_2/database.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/database.sp
@@ -34,7 +34,7 @@ void Database_PluginStart()
 	}
 }
 
-public void Database_Connected(Database db, const char[] error, any data)
+static void Database_Connected(Database db, const char[] error, any data)
 {
 	if(db)
 	{
@@ -65,7 +65,7 @@ public void Database_Connected(Database db, const char[] error, any data)
 	}
 }
 
-public Action Database_SteamIdCmd(int args)
+static Action Database_SteamIdCmd(int args)
 {
 	if(args)
 	{
@@ -94,7 +94,7 @@ public Action Database_SteamIdCmd(int args)
 	return Plugin_Handled;
 }
 
-public Action Database_QueryCmd(int args)
+static Action Database_QueryCmd(int args)
 {
 	char buffer[1024];
 	GetCmdArgString(buffer, sizeof(buffer));
@@ -107,7 +107,7 @@ public Action Database_QueryCmd(int args)
 	return Plugin_Handled;
 }
 
-public void Database_QueryCallback(Database db, any data, int numQueries, DBResultSet[] results, any[] queryData)
+static void Database_QueryCallback(Database db, any data, int numQueries, DBResultSet[] results, any[] queryData)
 {
 	PrintToServer("Success");
 	
@@ -126,12 +126,12 @@ public void Database_QueryCallback(Database db, any data, int numQueries, DBResu
 	}
 }
 
-public void Database_QueryFail(Database db, any data, int numQueries, const char[] error, int failIndex, any[] queryData)
+static void Database_QueryFail(Database db, any data, int numQueries, const char[] error, int failIndex, any[] queryData)
 {
 	PrintToServer(error);
 }
 
-public void Database_SetupCallback(Database db, any data, int numQueries, DBResultSet[] results, any[] queryData)
+static void Database_SetupCallback(Database db, any data, int numQueries, DBResultSet[] results, any[] queryData)
 {
 	DataBase = data;
 	for(int client = 1; client <= MaxClients; client++)
@@ -179,7 +179,7 @@ void Database_ClientPostAdminCheck(int client)
 	}
 }
 
-public void Database_ClientSetup(Database db, int userid, int numQueries, DBResultSet[] results, any[] queryData)
+static void Database_ClientSetup(Database db, int userid, int numQueries, DBResultSet[] results, any[] queryData)
 {
 	int client = GetClientOfUserId(userid);
 	if(client)
@@ -303,16 +303,16 @@ void Database_ClientDisconnect(int client, DBPriority priority = DBPrio_Normal)
 	Preference_ClearArrays(client);
 }
 
-public void Database_Success(Database db, any data, int numQueries, DBResultSet[] results, any[] queryData)
+static void Database_Success(Database db, any data, int numQueries, DBResultSet[] results, any[] queryData)
 {
 }
 
-public void Database_Fail(Database db, any data, int numQueries, const char[] error, int failIndex, any[] queryData)
+static void Database_Fail(Database db, any data, int numQueries, const char[] error, int failIndex, any[] queryData)
 {
 	LogError("[Database] %s", error);
 }
 
-public void Database_FailHandle(Database db, any data, int numQueries, const char[] error, int failIndex, any[] queryData)
+static void Database_FailHandle(Database db, any data, int numQueries, const char[] error, int failIndex, any[] queryData)
 {
 	LogError("[Database] %s", error);
 	CloseHandle(data);

--- a/addons/sourcemod/scripting/freak_fortress_2/dhooks.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/dhooks.sp
@@ -158,7 +158,7 @@ void DHook_EntityDestoryed()
 	RequestFrame(DHook_EntityDestoryedFrame);
 }
 
-public void DHook_EntityDestoryedFrame()
+static void DHook_EntityDestoryedFrame()
 {
 	int length = RawEntityHooks.Length;
 	if(length)
@@ -238,7 +238,7 @@ Address DHook_GetLagCompensationManager()
 	return CLagCompensationManager;
 }
 
-public void DHook_RoundSetup(Event event, const char[] name, bool dontBroadcast)
+static void DHook_RoundSetup(Event event, const char[] name, bool dontBroadcast)
 {
 	DHook_RoundRespawn();	// Back up plan
 	
@@ -249,7 +249,7 @@ public void DHook_RoundSetup(Event event, const char[] name, bool dontBroadcast)
 	}
 }
 
-public MRESReturn DHook_CanPickupDroppedWeaponPre(int client, DHookReturn ret, DHookParam param)
+static MRESReturn DHook_CanPickupDroppedWeaponPre(int client, DHookReturn ret, DHookParam param)
 {
 	switch(Forward_OnPickupDroppedWeapon(client, param.Get(1)))
 	{
@@ -276,12 +276,12 @@ public MRESReturn DHook_CanPickupDroppedWeaponPre(int client, DHookReturn ret, D
 	return MRES_Ignored;
 }
 
-public MRESReturn DHook_ChangeTeamPre(int client, DHookParam param)
+static MRESReturn DHook_ChangeTeamPre(int client, DHookParam param)
 {
 	return MRES_Supercede;
 }
 
-public MRESReturn DHook_ChangeTeamPost(int client, DHookParam param)
+static MRESReturn DHook_ChangeTeamPost(int client, DHookParam param)
 {
 	if(param.Get(1) % 2)
 	{
@@ -294,12 +294,12 @@ public MRESReturn DHook_ChangeTeamPost(int client, DHookParam param)
 	return MRES_Ignored;
 }
 
-public MRESReturn DHook_DropAmmoPackPre(int client, DHookParam param)
+static MRESReturn DHook_DropAmmoPackPre(int client, DHookParam param)
 {
 	return (Client(client).Minion || Client(client).IsBoss) ? MRES_Supercede : MRES_Ignored;
 }
 
-public MRESReturn DHook_ForceRespawnPre(int client)
+static MRESReturn DHook_ForceRespawnPre(int client)
 {
 	PrefClass = 0;
 	if(Client(client).IsBoss)
@@ -316,7 +316,7 @@ public MRESReturn DHook_ForceRespawnPre(int client)
 	return MRES_Ignored;
 }
 
-public MRESReturn DHook_ForceRespawnPost(int client)
+static MRESReturn DHook_ForceRespawnPost(int client)
 {
 	if(PrefClass)
 		SetEntProp(client, Prop_Send, "m_iDesiredPlayerClass", PrefClass);
@@ -324,7 +324,7 @@ public MRESReturn DHook_ForceRespawnPost(int client)
 	return MRES_Ignored;
 }
 
-public MRESReturn DHook_GetCaptureValue(DHookReturn ret, DHookParam param)
+static MRESReturn DHook_GetCaptureValue(DHookReturn ret, DHookParam param)
 {
 	int client = param.Get(1);
 	if(!Client(client).IsBoss || Attributes_FindOnPlayer(client, 68))
@@ -334,7 +334,7 @@ public MRESReturn DHook_GetCaptureValue(DHookReturn ret, DHookParam param)
 	return MRES_Override;
 }
 
-public MRESReturn DHook_RegenThinkPre(int client, DHookParam param)
+static MRESReturn DHook_RegenThinkPre(int client, DHookParam param)
 {
 	if(Client(client).IsBoss && TF2_GetPlayerClass(client) == TFClass_Medic)
 		TF2_SetPlayerClass(client, TFClass_Unknown, _, false);
@@ -342,7 +342,7 @@ public MRESReturn DHook_RegenThinkPre(int client, DHookParam param)
 	return MRES_Ignored;
 }
 
-public MRESReturn DHook_RegenThinkPost(int client, DHookParam param)
+static MRESReturn DHook_RegenThinkPost(int client, DHookParam param)
 {
 	if(Client(client).IsBoss && TF2_GetPlayerClass(client) == TFClass_Unknown)
 		TF2_SetPlayerClass(client, TFClass_Medic, _, false);
@@ -350,25 +350,25 @@ public MRESReturn DHook_RegenThinkPost(int client, DHookParam param)
 	return MRES_Ignored;
 }
 
-public MRESReturn DHook_ResetRoundStats(Address address)
+static MRESReturn DHook_ResetRoundStats(Address address)
 {
 	CTFGameStats = address;
 	return MRES_Ignored;
 }
 
-public MRESReturn DHook_RoundRespawn()
+static MRESReturn DHook_RoundRespawn()
 {
 	Gamemode_RoundSetup();
 	return MRES_Ignored;
 }
 
-public MRESReturn DHook_StartLagCompensation(Address address)
+static MRESReturn DHook_StartLagCompensation(Address address)
 {
 	CLagCompensationManager = address;
 	return MRES_Ignored;
 }
 
-public MRESReturn DHook_SetWinningTeam(DHookParam param)
+static MRESReturn DHook_SetWinningTeam(DHookParam param)
 {
 	if(Enabled && RoundStatus == 1 && Cvar[SpecTeam].BoolValue && param.Get(2) == WINREASON_OPPONENTS_DEAD)
 	{
@@ -404,7 +404,7 @@ public MRESReturn DHook_SetWinningTeam(DHookParam param)
 	return MRES_Ignored;
 }
 
-public MRESReturn DHook_KnifeInjuredPre(int entity, DHookParam param)
+static MRESReturn DHook_KnifeInjuredPre(int entity, DHookParam param)
 {
 	if(DamageTypeOffset != -1 && !param.IsNull(2) && Client(param.Get(2)).IsBoss)
 	{
@@ -420,7 +420,7 @@ public MRESReturn DHook_KnifeInjuredPre(int entity, DHookParam param)
 	return MRES_Ignored;
 }
 
-public MRESReturn DHook_KnifeInjuredPost(int entity, DHookParam param)
+static MRESReturn DHook_KnifeInjuredPost(int entity, DHookParam param)
 {
 	if(KnifeWasChanged != -1)
 	{
@@ -431,7 +431,7 @@ public MRESReturn DHook_KnifeInjuredPost(int entity, DHookParam param)
 	return MRES_Ignored;
 }
 
-public MRESReturn DHook_ApplyPostHitPre(int entity, DHookParam param)
+static MRESReturn DHook_ApplyPostHitPre(int entity, DHookParam param)
 {
 	int client = param.Get(2);
 	if(Client(client).IsBoss)
@@ -443,7 +443,7 @@ public MRESReturn DHook_ApplyPostHitPre(int entity, DHookParam param)
 	return MRES_Ignored;
 }
 
-public MRESReturn DHook_ApplyPostHitPost(int entity, DHookParam param)
+static MRESReturn DHook_ApplyPostHitPost(int entity, DHookParam param)
 {
 	if(EffectClass != -1)
 	{
@@ -454,13 +454,13 @@ public MRESReturn DHook_ApplyPostHitPost(int entity, DHookParam param)
 	return MRES_Ignored;
 }
 
-public MRESReturn DHook_IterateAttributesPre(Address pThis, DHookParam hParams)
+static MRESReturn DHook_IterateAttributesPre(Address pThis, DHookParam hParams)
 {
     StoreToAddress(pThis + view_as<Address>(m_bOnlyIterateItemViewAttributes), true, NumberType_Int8);
     return MRES_Ignored;
 }
 
-public MRESReturn DHook_IterateAttributesPost(Address pThis, DHookParam hParams)
+static MRESReturn DHook_IterateAttributesPost(Address pThis, DHookParam hParams)
 {
     StoreToAddress(pThis + view_as<Address>(m_bOnlyIterateItemViewAttributes), false, NumberType_Int8);
     return MRES_Ignored;

--- a/addons/sourcemod/scripting/freak_fortress_2/events.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/events.sp
@@ -141,19 +141,19 @@ void Events_CheckAlivePlayers(int exclude = 0, bool alive = true, bool resetMax 
 		Gamemode_CheckPointUnlock(total, !LastMann);
 }
 
-public void Events_RoundStart(Event event, const char[] name, bool dontBroadcast)
+static void Events_RoundStart(Event event, const char[] name, bool dontBroadcast)
 {
 	FirstBlood = true;
 	LastMann = false;
 	Gamemode_RoundStart();
 }
 
-public void Events_RoundEnd(Event event, const char[] name, bool dontBroadcast)
+static void Events_RoundEnd(Event event, const char[] name, bool dontBroadcast)
 {
 	Gamemode_RoundEnd(event.GetInt("team"));
 }
 
-public Action Events_BroadcastAudio(Event event, const char[] name, bool dontBroadcast)
+static Action Events_BroadcastAudio(Event event, const char[] name, bool dontBroadcast)
 {
 	if(Enabled)
 	{
@@ -165,7 +165,7 @@ public Action Events_BroadcastAudio(Event event, const char[] name, bool dontBro
 	return Plugin_Continue;
 }
 
-public Action Events_ObjectDeflected(Event event, const char[] name, bool dontBroadcast)
+static Action Events_ObjectDeflected(Event event, const char[] name, bool dontBroadcast)
 {
 	if(!event.GetInt("weaponid"))
 	{
@@ -180,7 +180,7 @@ public Action Events_ObjectDeflected(Event event, const char[] name, bool dontBr
 	return Plugin_Continue;
 }
 
-public Action Events_ObjectDestroyed(Event event, const char[] name, bool dontBroadcast)
+static Action Events_ObjectDestroyed(Event event, const char[] name, bool dontBroadcast)
 {
 	TFObjectType type = view_as<TFObjectType>(event.GetInt("objecttype"));
 	if(Enabled && type == TFObject_Teleporter)
@@ -210,7 +210,7 @@ public Action Events_ObjectDestroyed(Event event, const char[] name, bool dontBr
 	return Plugin_Continue;
 }
 
-public void Events_PlayerSpawn(Event event, const char[] name, bool dontBroadcast)
+static void Events_PlayerSpawn(Event event, const char[] name, bool dontBroadcast)
 {
 	int client = GetClientOfUserId(event.GetInt("userid"));
 	if(client && Cvar[DisguiseModels].BoolValue)
@@ -222,7 +222,7 @@ public void Events_PlayerSpawn(Event event, const char[] name, bool dontBroadcas
 	Events_CheckAlivePlayers();
 }
 
-public Action Events_InventoryApplication(Event event, const char[] name, bool dontBroadcast)
+static Action Events_InventoryApplication(Event event, const char[] name, bool dontBroadcast)
 {
 	int userid = event.GetInt("userid");
 	int client = GetClientOfUserId(userid);
@@ -285,7 +285,7 @@ public Action Events_InventoryApplication(Event event, const char[] name, bool d
 	return Plugin_Continue;
 }
 
-public void Events_PlayerHealed(Event event, const char[] name, bool dontBroadcast)
+static void Events_PlayerHealed(Event event, const char[] name, bool dontBroadcast)
 {
 	if(Cvar[RefreshDmg].BoolValue)
 	{
@@ -299,7 +299,7 @@ public void Events_PlayerHealed(Event event, const char[] name, bool dontBroadca
 	}
 }
 
-public Action Events_PlayerHurt(Event event, const char[] name, bool dontBroadcast)
+static Action Events_PlayerHurt(Event event, const char[] name, bool dontBroadcast)
 {
 	bool changed;
 	int victim = GetClientOfUserId(event.GetInt("userid"));
@@ -466,7 +466,7 @@ public Action Events_PlayerHurt(Event event, const char[] name, bool dontBroadca
 	return changed ? Plugin_Changed : Plugin_Continue;
 }
 
-public void Events_PlayerDeath(Event event, const char[] name, bool dontBroadcast)
+static void Events_PlayerDeath(Event event, const char[] name, bool dontBroadcast)
 {
 	if(!Enabled || RoundStatus == 1)
 	{
@@ -627,7 +627,7 @@ public void Events_PlayerDeath(Event event, const char[] name, bool dontBroadcas
 	}
 }
 
-public Action Events_WinPanel(Event event, const char[] name, bool dontBroadcast)
+static Action Events_WinPanel(Event event, const char[] name, bool dontBroadcast)
 {
 	if(Enabled)
 	{
@@ -732,7 +732,7 @@ public Action Events_WinPanel(Event event, const char[] name, bool dontBroadcast
 	return Plugin_Continue;
 }
 
-public void Events_RPSTaunt(Event event, const char[] name, bool dontBroadcast)
+static void Events_RPSTaunt(Event event, const char[] name, bool dontBroadcast)
 {
 	int victim = event.GetInt("loser");
 	if(Client(victim).IsBoss)

--- a/addons/sourcemod/scripting/freak_fortress_2/filenetwork.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/filenetwork.sp
@@ -110,7 +110,7 @@ void FileNet_AddFileToDownloads(const char[] raw)
 			}
 		}
 
-		//return;
+		return;
 	}
 	#endif
 

--- a/addons/sourcemod/scripting/freak_fortress_2/filenetwork.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/filenetwork.sp
@@ -1,0 +1,303 @@
+/*
+	void TFED_PluginLoad()
+	void TFED_PluginStart()
+	void TFED_LibraryAdded(const char[] name)
+	void TFED_LibraryRemoved(const char[] name)
+	bool TFED_GetItemDefinitionString(int itemdef, const char[] key, char[] buffer, int maxlen, const char[] defaultValue = NULL_STRING)
+	bool TF2ED_GetLocalizedItemName(int itemdef, char[] name, int maxlen, const char[] classname = NULL_STRING)
+	bool TF2ED_GetAttributeDefinitionString(int attrdef, const char[] key, char[] buffer, int maxlen, const char[] defaultValue = NULL_STRING)
+	int TF2ED_TranslateAttributeNameToDefinitionIndex(const char[] name)
+*/
+
+#tryinclude <filenetwork>
+
+#pragma semicolon 1
+#pragma newdecls required
+
+#define FILENET_LIBRARY	"filenetwork"
+
+#if defined _filenetwork_included
+static bool Loaded;
+
+static bool StartedQueue[MAXTF2PLAYERS];
+static bool Downloading[MAXTF2PLAYERS];
+
+static ArrayList FileList;
+static int FileProgress[MAXTF2PLAYERS];
+#endif
+
+void FileNet_PluginStart()
+{
+	#if defined _filenetwork_included
+	Loaded = LibraryExists(FILENET_LIBRARY);
+	FileList = new ArrayList(ByteCountToCells(PLATFORM_MAX_PATH));
+	RegServerCmd("ff2_filenetwork", FileNet_Command, "View files to download via filenetwork");
+	#endif
+}
+
+stock void FileNet_LibraryAdded(const char[] name)
+{
+	#if defined _filenetwork_included
+	if(!Loaded && StrEqual(name, FILENET_LIBRARY))
+	{
+		Loaded = true;
+
+		for(int client = 1; client <= MaxClients; client++)
+		{
+			if(StartedQueue[client] && !Downloading[client])
+				SendNextFile(client);
+		}
+	}
+	#endif
+}
+
+stock void FileNet_LibraryRemoved(const char[] name)
+{
+	#if defined _filenetwork_included
+	if(Loaded && StrEqual(name, FILENET_LIBRARY))
+		Loaded = false;
+	#endif
+}
+
+void FileNet_MapEnd()
+{
+	#if defined _filenetwork_included
+	for(int i; i < sizeof(FileProgress); i++)
+	{
+		FileProgress[i] = 0;
+	}
+
+	delete FileList;
+
+	FileNet_PluginStart();
+	#endif
+}
+
+void FileNet_ClientPutInServer(int client)
+{
+	#if defined _filenetwork_included
+	FileNet_ClientDisconnect(client);
+	SendNextFile(client);
+	#endif
+}
+
+void FileNet_ClientDisconnect(int client)
+{
+	#if defined _filenetwork_included
+	StartedQueue[client] = false;
+	Downloading[client] = false;
+	FileProgress[client] = 0;
+	#endif
+}
+
+void FileNet_AddFileToDownloads(const char[] raw)
+{
+	#if defined _filenetwork_included
+	if(Loaded)
+	{
+		char file[PLATFORM_MAX_PATH];
+		strcopy(file, sizeof(file), raw);
+		FormatFile(file, sizeof(file));
+
+		if(FileList.FindString(file) == -1)
+		{
+			FileList.PushString(file);
+			
+			for(int client = 1; client <= MaxClients; client++)
+			{
+				if(StartedQueue[client] && !Downloading[client])
+					SendNextFile(client);
+			}
+		}
+
+		//return;
+	}
+	#endif
+
+	AddFileToDownloadsTable(raw);
+}
+
+stock bool FileNet_HasFile(int client, int progress)
+{
+	#if defined _filenetwork_included
+	return FileProgress[client] >= progress;
+	#else
+	return true;
+	#endif
+}
+
+stock int FileNet_FileProgress(const char[] raw)
+{
+	#if defined _filenetwork_included
+	char file[PLATFORM_MAX_PATH];
+	strcopy(file, sizeof(file), raw);
+	FormatFile(file, sizeof(file));
+
+	return FileList.FindString(file) + 1;
+	#else
+	return 0;
+	#endif
+}
+
+stock int FileNet_SoundProgress(const char[] sound)
+{
+	#if defined _filenetwork_included
+	char file[PLATFORM_MAX_PATH];
+	FormatEx(file, sizeof(file), "sound/%s", sound);
+	ReplaceString(file, sizeof(file), "*", "");
+	ReplaceString(file, sizeof(file), "#", "");
+	ReplaceString(file, sizeof(file), "@", "");
+	ReplaceString(file, sizeof(file), ">", "");
+	ReplaceString(file, sizeof(file), "<", "");
+	ReplaceString(file, sizeof(file), "^", "");
+	ReplaceString(file, sizeof(file), ")", "");
+	ReplaceString(file, sizeof(file), "}", "");
+	ReplaceString(file, sizeof(file), "!", "");
+	ReplaceString(file, sizeof(file), "?", "");
+	FormatFile(file, sizeof(file));
+
+	return FileList.FindString(file) + 1;
+	#else
+	return 0;
+	#endif
+}
+
+#if defined _filenetwork_included
+static Action FileNet_Command(int args)
+{
+	int length = FileList.Length;
+	PrintToServer("Listing %d files:", length);
+
+	char file[PLATFORM_MAX_PATH];
+	for(int i; i < length; i++)
+	{
+		FileList.GetString(i, file, sizeof(file));
+		PrintToServer("\"%s\"", file);
+	}
+	return Plugin_Handled;
+}
+
+static void FormatFile(char[] file, int length)
+{
+	ReplaceString(file, length, "\\", "/");
+}
+
+static void FormatFileCheck(const char[] file, int client, char[] output, int length)
+{
+	strcopy(output, length, file);
+	ReplaceString(output, length, ".", "");
+	Format(output, length, "%s_%d.txt", output, GetSteamAccountID(client, false));
+}
+
+static void SendNextFile(int client)
+{
+	StartedQueue[client] = true;
+	
+	if(Loaded && FileProgress[client] < FileList.Length)
+	{
+		char file[PLATFORM_MAX_PATH];
+		FileList.GetString(FileProgress[client], file, sizeof(file));
+
+		DataPack pack = new DataPack();
+
+		Downloading[client] = true;
+
+		pack.WriteString(file);
+		
+		// First, request a dummy file to see if they have it downloaded before
+		char filecheck[PLATFORM_MAX_PATH];
+		FormatFileCheck(file, client, filecheck, sizeof(filecheck));
+		FileNet_RequestFile(client, filecheck, FileNetwork_RequestResults, pack);
+
+		// There may be some cases where we still have the file (Eg. plugin unload)
+		if(!DeleteFile(filecheck, true))
+		{
+			Format(filecheck, sizeof(filecheck), "download/%s", filecheck);
+			DeleteFile(filecheck);
+		}
+	}
+	else
+	{
+		Downloading[client] = false;
+	}
+}
+
+static void FileNetwork_RequestResults(int client, const char[] file, int id, bool success, DataPack pack)
+{
+	if(success)
+	{
+		// Delete the dummy file we downloaded
+		if(!DeleteFile(file, true))
+		{
+			char filecheck[PLATFORM_MAX_PATH];
+			Format(filecheck, sizeof(filecheck), "download/%s", file);
+			DeleteFile(filecheck);
+		}
+	}
+
+	if(!StartedQueue[client])
+	{
+		// Client has disconnected
+		delete pack;
+		return;
+	}
+
+	char download[PLATFORM_MAX_PATH];
+	pack.Reset();
+	pack.ReadString(download, sizeof(download));
+	delete pack;
+
+	if(success)
+	{
+		// Found, check the next file
+		FileProgress[client]++;
+		SendNextFile(client);
+	}
+	else
+	{
+		// Not found, send the actual file
+		if(!FileNet_SendFile(client, download, FileNetwork_SendResults))
+			LogError("Failed to queue file \"%s\" to client", download);
+	}
+}
+
+static void FileNetwork_SendResults(int client, const char[] file, bool success)
+{
+	if(StartedQueue[client])
+	{
+		if(success)
+		{
+			// When done, send a dummy file
+			char filecheck[PLATFORM_MAX_PATH];
+			FormatFileCheck(file, client, filecheck, sizeof(filecheck));
+
+			File check = OpenFile(filecheck, "wt");
+			check.WriteLine("Used for file checks for FF2");
+			check.Close();
+
+			if(!FileNet_SendFile(client, filecheck, FileNetwork_SendFileCheck))
+			{
+				LogError("Failed to queue file \"%s\" to client", filecheck);
+				DeleteFile(filecheck);
+			}
+
+			// Move on to the next file
+			FileProgress[client]++;
+			SendNextFile(client);
+		}
+		else
+		{
+			LogError("Failed to send file \"%s\" to client", file);
+		}
+	}
+}
+
+static void FileNetwork_SendFileCheck(int client, const char[] file, bool success)
+{
+	if(StartedQueue[client] && !success)
+		LogError("Failed to send file \"%s\" to client", file);
+	
+	// Delete the dummy file left over
+	DeleteFile(file);
+}
+#endif

--- a/addons/sourcemod/scripting/freak_fortress_2/filenetwork.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/filenetwork.sp
@@ -73,7 +73,7 @@ void FileNet_MapEnd()
 	#endif
 }
 
-void FileNet_ClientPutInServer(int client)
+stock void FileNet_ClientPutInServer(int client)
 {
 	#if defined _filenetwork_included
 	FileNet_ClientDisconnect(client);
@@ -81,7 +81,7 @@ void FileNet_ClientPutInServer(int client)
 	#endif
 }
 
-void FileNet_ClientDisconnect(int client)
+stock void FileNet_ClientDisconnect(int client)
 {
 	#if defined _filenetwork_included
 	StartedQueue[client] = false;

--- a/addons/sourcemod/scripting/freak_fortress_2/gamemode.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/gamemode.sp
@@ -320,7 +320,7 @@ public void TF2_OnWaitingForPlayersEnd()
 		Cvar[MovementFreeze].BoolValue = true;
 }
 
-public Action Gamemode_TimerRespawn(Handle timer)
+static Action Gamemode_TimerRespawn(Handle timer)
 {
 	if(!GameRules_GetProp("m_bInWaitingForPlayers", 1))
 		return Plugin_Stop;
@@ -335,7 +335,7 @@ public Action Gamemode_TimerRespawn(Handle timer)
 	return Plugin_Continue;
 }
 
-public Action Gamemode_BackupWaiting(Handle timer)
+static Action Gamemode_BackupWaiting(Handle timer)
 {
 	// There is some cases where waiting for players could get stuck and fail to restart the round
 	// Here's the duct tape fix until I can find a way to properly patch it
@@ -349,7 +349,7 @@ public Action Gamemode_BackupWaiting(Handle timer)
 	return Plugin_Continue;
 }
 
-public Action Gamemode_IntroTimer(Handle timer)
+static Action Gamemode_IntroTimer(Handle timer)
 {
 	for(int client = 1; client <= MaxClients; client++)
 	{
@@ -381,7 +381,7 @@ public Action Gamemode_IntroTimer(Handle timer)
 	return Plugin_Continue;
 }
 
-public Action Gamemode_SetControlPoint(Handle timer)
+static Action Gamemode_SetControlPoint(Handle timer)
 {
 	Events_CheckAlivePlayers();
 	
@@ -1088,7 +1088,7 @@ static int SetTeamBasedHealthBar(int health1, int team1)
 	return health2;
 }
 
-public Action Gamemode_UpdateHudTimer(Handle timer, int team)
+static Action Gamemode_UpdateHudTimer(Handle timer, int team)
 {
 	HudTimer[team] = null;
 	Gamemode_UpdateHUD(team);
@@ -1215,7 +1215,7 @@ void Gamemode_ConditionRemoved(int client, TFCond cond)
 	}
 }
 
-public Action Gamemode_DisguiseTimer(Handle timer, int userid)
+static Action Gamemode_DisguiseTimer(Handle timer, int userid)
 {
 	int client = GetClientOfUserId(userid);
 	if(client && TF2_IsPlayerInCondition(client, TFCond_Disguised))

--- a/addons/sourcemod/scripting/freak_fortress_2/menu.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/menu.sp
@@ -37,7 +37,7 @@ bool Menu_BackButton(int client)
 	return InMainMenu[client];
 }
 
-public Action Menu_MainMenuCmd(int client, int args)
+static Action Menu_MainMenuCmd(int client, int args)
 {
 	if(!client)
 	{
@@ -129,7 +129,7 @@ void Menu_MainMenu(int client)
 	menu.Display(client, MENU_TIME_FOREVER);
 }
 
-public int Menu_MainMenuH(Menu menu, MenuAction action, int client, int choice)
+static int Menu_MainMenuH(Menu menu, MenuAction action, int client, int choice)
 {
 	switch(action)
 	{
@@ -177,7 +177,7 @@ public int Menu_MainMenuH(Menu menu, MenuAction action, int client, int choice)
 	return 0;
 }
 
-public Action Menu_VoiceToggle(int client, int args)
+static Action Menu_VoiceToggle(int client, int args)
 {
 	if(client)
 	{
@@ -191,7 +191,7 @@ public Action Menu_VoiceToggle(int client, int args)
 	return Plugin_Handled;
 }
 
-public Action Menu_QueueMenuCmd(int client, int args)
+static Action Menu_QueueMenuCmd(int client, int args)
 {
 	if(GetCmdReplySource() == SM_REPLY_TO_CONSOLE)
 	{
@@ -257,7 +257,7 @@ static void QueueMenu(int client)
 	menu.Display(client, MENU_TIME_FOREVER);
 }
 
-public int Menu_QueueMenuH(Menu menu, MenuAction action, int client, int choice)
+static int Menu_QueueMenuH(Menu menu, MenuAction action, int client, int choice)
 {
 	switch(action)
 	{
@@ -304,7 +304,7 @@ static void ResetQueueMenu(int client)
 	menu.Display(client, MENU_TIME_FOREVER);
 }
 
-public int ResetQueueMenuH(Menu menu, MenuAction action, int client, int choice)
+static int ResetQueueMenuH(Menu menu, MenuAction action, int client, int choice)
 {
 	switch(action)
 	{
@@ -323,7 +323,7 @@ public int ResetQueueMenuH(Menu menu, MenuAction action, int client, int choice)
 	return 0;
 }
 
-public Action Menu_HudToggle(int client, int args)
+static Action Menu_HudToggle(int client, int args)
 {
 	if(client)
 	{
@@ -337,7 +337,7 @@ public Action Menu_HudToggle(int client, int args)
 	return Plugin_Handled;
 }
 
-public Action Menu_AddPointsCmd(int client, int args)
+static Action Menu_AddPointsCmd(int client, int args)
 {
 	if(args == 2)
 	{
@@ -402,7 +402,7 @@ static void AddPointsMenu(int client, const char[] userid = NULL_STRING)
 	}
 }
 
-public int Menu_AddPointsTargetH(Menu menu, MenuAction action, int client, int choice)
+static int Menu_AddPointsTargetH(Menu menu, MenuAction action, int client, int choice)
 {
 	switch(action)
 	{
@@ -420,7 +420,7 @@ public int Menu_AddPointsTargetH(Menu menu, MenuAction action, int client, int c
 	return 0;
 }
 
-public int Menu_AddPointsActionH(Menu menu, MenuAction action, int client, int choice)
+static int Menu_AddPointsActionH(Menu menu, MenuAction action, int client, int choice)
 {
 	switch(action)
 	{

--- a/addons/sourcemod/scripting/freak_fortress_2/natives.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/natives.sp
@@ -23,11 +23,12 @@ void Native_PluginLoad()
 	CreateNative("FF2R_UpdateBossAttributes", Native_UpdateBossAttributes);
 	CreateNative("FF2R_GetClientHud", Native_GetClientHud);
 	CreateNative("FF2R_SetClientHud", Native_SetClientHud);
+	CreateNative("FF2R_ClientHasFile", Native_ClientHasFile);
 	
 	RegPluginLibrary("ff2r");
 }
 
-public any Native_GetBossData(Handle plugin, int params)
+static any Native_GetBossData(Handle plugin, int params)
 {
 	int client = GetNativeCell(1);
 	if(client < 0 || client >= MAXTF2PLAYERS)
@@ -36,7 +37,7 @@ public any Native_GetBossData(Handle plugin, int params)
 	return Client(client).Cfg;
 }
 
-public any Native_SetBossData(Handle plugin, int params)
+static any Native_SetBossData(Handle plugin, int params)
 {
 	int client = GetNativeCell(1);
 	if(client < 1 || client > MaxClients || !IsClientInGame(client))
@@ -73,7 +74,7 @@ public any Native_SetBossData(Handle plugin, int params)
 	return 0;
 }
 
-public any Native_EmitBossSound(Handle plugin, int params)
+static any Native_EmitBossSound(Handle plugin, int params)
 {
 	int boss = GetNativeCell(4);
 	if(boss < 1 || boss > MaxClients || !Client(boss).Cfg)
@@ -99,7 +100,7 @@ public any Native_EmitBossSound(Handle plugin, int params)
 	return Bosses_PlaySound(boss, clients, amount, sample, required, GetNativeCell(6), GetNativeCell(7), GetNativeCell(8), GetNativeCell(9), GetNativeCell(10), GetNativeCell(11), GetNativeCell(12), origin, dir, GetNativeCell(15), GetNativeCell(16));
 }
 
-public any Native_DoBossSlot(Handle plugin, int params)
+static any Native_DoBossSlot(Handle plugin, int params)
 {
 	int client = GetNativeCell(1);
 	if(client < 1 || client > MaxClients || !Client(client).Cfg)
@@ -114,12 +115,12 @@ public any Native_DoBossSlot(Handle plugin, int params)
 	return 0;
 }
 
-public any Native_GetSpecialData(Handle plugin, int params)
+static any Native_GetSpecialData(Handle plugin, int params)
 {
 	return Bosses_GetConfig(GetNativeCell(1));
 }
 
-public any Native_CreateBoss(Handle plugin, int params)
+static any Native_CreateBoss(Handle plugin, int params)
 {
 	int client = GetNativeCell(1);
 	if(client < 1 || client > MaxClients || !IsClientInGame(client))
@@ -139,7 +140,7 @@ public any Native_CreateBoss(Handle plugin, int params)
 	return 0;
 }
 
-public any Native_GetClientMinion(Handle plugin, int params)
+static any Native_GetClientMinion(Handle plugin, int params)
 {
 	int client = GetNativeCell(1);
 	if(client < 0 || client >= MAXTF2PLAYERS)
@@ -148,7 +149,7 @@ public any Native_GetClientMinion(Handle plugin, int params)
 	return Client(client).Minion;
 }
 
-public any Native_SetClientMinion(Handle plugin, int params)
+static any Native_SetClientMinion(Handle plugin, int params)
 {
 	int client = GetNativeCell(1);
 	if(client < 1 || client > MaxClients || !IsClientInGame(client))
@@ -158,7 +159,7 @@ public any Native_SetClientMinion(Handle plugin, int params)
 	return 0;
 }
 
-public any Native_GetClientScore(Handle plugin, int params)
+static any Native_GetClientScore(Handle plugin, int params)
 {
 	int client = GetNativeCell(1);
 	if(client < 0 || client >= MAXTF2PLAYERS)
@@ -170,17 +171,17 @@ public any Native_GetClientScore(Handle plugin, int params)
 	return Client(client).TotalDamage + Client(client).Healing + Client(client).TotalAssist;
 }
 
-public any Native_GetPluginHandle(Handle plugin, int params)
+static any Native_GetPluginHandle(Handle plugin, int params)
 {
 	return ThisPlugin;
 }
 
-public any Native_GetGamemodeType(Handle plugin, int params)
+static any Native_GetGamemodeType(Handle plugin, int params)
 {
 	return Enabled ? 2 : (Charset != -1 ? 1 : 0);
 }
 
-public any Native_StartLagCompensation(Handle plugin, int params)
+static any Native_StartLagCompensation(Handle plugin, int params)
 {
 	int client = GetNativeCell(1);
 	if(client < 1 || client > MaxClients || !IsClientInGame(client))
@@ -190,7 +191,7 @@ public any Native_StartLagCompensation(Handle plugin, int params)
 	return 0;
 }
 
-public any Native_FinishLagCompensation(Handle plugin, int params)
+static any Native_FinishLagCompensation(Handle plugin, int params)
 {
 	int client = GetNativeCell(1);
 	if(client < 1 || client > MaxClients || !IsClientInGame(client))
@@ -200,7 +201,7 @@ public any Native_FinishLagCompensation(Handle plugin, int params)
 	return 0;
 }
 
-public any Native_UpdateBossAttributes(Handle plugin, int params)
+static any Native_UpdateBossAttributes(Handle plugin, int params)
 {
 	int client = GetNativeCell(1);
 	if(client < 1 || client > MaxClients || !Client(client).Cfg)
@@ -212,7 +213,7 @@ public any Native_UpdateBossAttributes(Handle plugin, int params)
 	return 0;
 }
 
-public any Native_GetClientHud(Handle plugin, int params)
+static any Native_GetClientHud(Handle plugin, int params)
 {
 	int client = GetNativeCell(1);
 	if(client < 0 || client >= MAXTF2PLAYERS)
@@ -221,7 +222,7 @@ public any Native_GetClientHud(Handle plugin, int params)
 	return !Client(client).NoHud;
 }
 
-public any Native_SetClientHud(Handle plugin, int params)
+static any Native_SetClientHud(Handle plugin, int params)
 {
 	int client = GetNativeCell(1);
 	if(client < 1 || client > MaxClients || !IsClientInGame(client))
@@ -229,4 +230,25 @@ public any Native_SetClientHud(Handle plugin, int params)
 	
 	Client(client).NoHud = !GetNativeCell(2);
 	return 0;
+}
+
+static any Native_ClientHasFile(Handle plugin, int numParams)
+{
+	int client = GetNativeCell(1);
+	if(client != 0 && (client < 1 || client > MaxClients || !IsClientInGame(client)))
+		return ThrowNativeError(SP_ERROR_NATIVE, "Client index %d is not in-game", client);
+	
+	int length;
+	GetNativeStringLength(2, length);
+	char[] file = new char[++length];
+	GetNativeString(2, file, length);
+
+	int table = FindStringTable("downloadables");
+	if(table != INVALID_STRING_TABLE)
+	{
+		if(FindStringIndex(table, file) != INVALID_STRING_INDEX)
+			return true;
+	}
+
+	return FileNet_HasFile(client, FileNet_FileProgress(file));
 }

--- a/addons/sourcemod/scripting/freak_fortress_2/natives_old.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/natives_old.sp
@@ -116,37 +116,37 @@ void NativeOld_PluginLoad()
 	RegPluginLibrary("saxtonhale");
 }
 
-public any NativeOld_IsEnabled(Handle plugin, int params)
+static any NativeOld_IsEnabled(Handle plugin, int params)
 {
 	return (Enabled && !GameRules_GetProp("m_bInWaitingForPlayers", 1));
 }
 
-public any NativeOld_FF2Version(Handle plugin, int params)
+static any NativeOld_FF2Version(Handle plugin, int params)
 {
 	static const int version[] = { 1, 11, 0 };
 	SetNativeArray(1, version, sizeof(version));
 	return true;
 }
 
-public any NativeOld_IsVersus(Handle plugin, int params)
+static any NativeOld_IsVersus(Handle plugin, int params)
 {
 	return true;
 }
 
-public any NativeOld_ForkVersion(Handle plugin, int params)
+static any NativeOld_ForkVersion(Handle plugin, int params)
 {
 	static const int version[] = { 2, 0, 0 };
 	SetNativeArray(1, version, sizeof(version));
 	return true;
 }
 
-public any NativeOld_GetBoss(Handle plugin, int params)
+static any NativeOld_GetBoss(Handle plugin, int params)
 {
 	int client = FindClientOfBossIndex(GetNativeCell(1));
 	return client == -1 ? client : GetClientUserId(client);
 }
 
-public any NativeOld_GetIndex(Handle plugin, int params)
+static any NativeOld_GetIndex(Handle plugin, int params)
 {
 	int client = GetNativeCell(1);
 	if(client > 0 && client < MAXTF2PLAYERS && Client(client).IsBoss)
@@ -155,12 +155,12 @@ public any NativeOld_GetIndex(Handle plugin, int params)
 	return -1;
 }
 
-public any NativeOld_GetTeam(Handle plugin, int params)
+static any NativeOld_GetTeam(Handle plugin, int params)
 {
 	return Bosses_GetBossTeam();
 }
 
-public any NativeOld_GetSpecial(Handle plugin, int params)
+static any NativeOld_GetSpecial(Handle plugin, int params)
 {
 	int index = GetNativeCell(1);
 	if(index < 0)
@@ -189,7 +189,7 @@ public any NativeOld_GetSpecial(Handle plugin, int params)
 	return true;
 }
 
-public any NativeOld_GetName(Handle plugin, int params)
+static any NativeOld_GetName(Handle plugin, int params)
 {
 	int index = GetNativeCell(1);
 	if(index < 0)
@@ -224,7 +224,7 @@ public any NativeOld_GetName(Handle plugin, int params)
 	return true;
 }
 
-public any NativeOld_GetBossHealth(Handle plugin, int params)
+static any NativeOld_GetBossHealth(Handle plugin, int params)
 {
 	int client = FindClientOfBossIndex(GetNativeCell(1));
 	if(client != -1)
@@ -233,7 +233,7 @@ public any NativeOld_GetBossHealth(Handle plugin, int params)
 	return 0;
 }
 
-public any NativeOld_SetBossHealth(Handle plugin, int params)
+static any NativeOld_SetBossHealth(Handle plugin, int params)
 {
 	int client = FindClientOfBossIndex(GetNativeCell(1));
 	if(client != -1)
@@ -249,7 +249,7 @@ public any NativeOld_SetBossHealth(Handle plugin, int params)
 	return 0;
 }
 
-public any NativeOld_GetBossMaxHealth(Handle plugin, int params)
+static any NativeOld_GetBossMaxHealth(Handle plugin, int params)
 {
 	int client = FindClientOfBossIndex(GetNativeCell(1));
 	if(client != -1)
@@ -258,7 +258,7 @@ public any NativeOld_GetBossMaxHealth(Handle plugin, int params)
 	return 0;
 }
 
-public any NativeOld_SetBossMaxHealth(Handle plugin, int params)
+static any NativeOld_SetBossMaxHealth(Handle plugin, int params)
 {
 	int client = FindClientOfBossIndex(GetNativeCell(1));
 	if(client != -1)
@@ -275,7 +275,7 @@ public any NativeOld_SetBossMaxHealth(Handle plugin, int params)
 	return 0;
 }
 
-public any NativeOld_GetBossLives(Handle plugin, int params)
+static any NativeOld_GetBossLives(Handle plugin, int params)
 {
 	int client = FindClientOfBossIndex(GetNativeCell(1));
 	if(client != -1)
@@ -284,7 +284,7 @@ public any NativeOld_GetBossLives(Handle plugin, int params)
 	return 0;
 }
 
-public any NativeOld_SetBossLives(Handle plugin, int params)
+static any NativeOld_SetBossLives(Handle plugin, int params)
 {
 	int client = FindClientOfBossIndex(GetNativeCell(1));
 	if(client != -1)
@@ -301,7 +301,7 @@ public any NativeOld_SetBossLives(Handle plugin, int params)
 	return 0;
 }
 
-public any NativeOld_GetBossMaxLives(Handle plugin, int params)
+static any NativeOld_GetBossMaxLives(Handle plugin, int params)
 {
 	int client = FindClientOfBossIndex(GetNativeCell(1));
 	if(client != -1)
@@ -310,7 +310,7 @@ public any NativeOld_GetBossMaxLives(Handle plugin, int params)
 	return 0;
 }
 
-public any NativeOld_SetBossMaxLives(Handle plugin, int params)
+static any NativeOld_SetBossMaxLives(Handle plugin, int params)
 {
 	int client = FindClientOfBossIndex(GetNativeCell(1));
 	if(client != -1)
@@ -324,7 +324,7 @@ public any NativeOld_SetBossMaxLives(Handle plugin, int params)
 	return 0;
 }
 
-public any NativeOld_GetBossCharge(Handle plugin, int params)
+static any NativeOld_GetBossCharge(Handle plugin, int params)
 {
 	int client = FindClientOfBossIndex(GetNativeCell(1));
 	if(client != -1)
@@ -333,7 +333,7 @@ public any NativeOld_GetBossCharge(Handle plugin, int params)
 	return 0.0;
 }
 
-public any NativeOld_SetBossCharge(Handle plugin, int params)
+static any NativeOld_SetBossCharge(Handle plugin, int params)
 {
 	int client = FindClientOfBossIndex(GetNativeCell(1));
 	if(client != -1)
@@ -342,7 +342,7 @@ public any NativeOld_SetBossCharge(Handle plugin, int params)
 	return 0;
 }
 
-public any NativeOld_GetBossRageDamage(Handle plugin, int params)
+static any NativeOld_GetBossRageDamage(Handle plugin, int params)
 {
 	int client = FindClientOfBossIndex(GetNativeCell(1));
 	if(client != -1)
@@ -351,7 +351,7 @@ public any NativeOld_GetBossRageDamage(Handle plugin, int params)
 	return 0;
 }
 
-public any NativeOld_SetBossRageDamage(Handle plugin, int params)
+static any NativeOld_SetBossRageDamage(Handle plugin, int params)
 {
 	int client = FindClientOfBossIndex(GetNativeCell(1));
 	if(client != -1)
@@ -360,7 +360,7 @@ public any NativeOld_SetBossRageDamage(Handle plugin, int params)
 	return 0;
 }
 
-public any NativeOld_GetRoundState(Handle plugin, int params)
+static any NativeOld_GetRoundState(Handle plugin, int params)
 {
 	return RoundStatus;
 	/*
@@ -377,7 +377,7 @@ public any NativeOld_GetRoundState(Handle plugin, int params)
 	*/
 }
 
-public any NativeOld_GetRageDist(Handle plugin, int params)
+static any NativeOld_GetRageDist(Handle plugin, int params)
 {
 	int client = FindClientOfBossIndex(GetNativeCell(1));
 	if(client == -1 || !Client(client).IsBoss)
@@ -393,7 +393,7 @@ public any NativeOld_GetRageDist(Handle plugin, int params)
 	return dist;
 }
 
-public any NativeOld_HasAbility(Handle plugin, int params)
+static any NativeOld_HasAbility(Handle plugin, int params)
 {
 	int client = FindClientOfBossIndex(GetNativeCell(1));
 	if(client != -1)
@@ -423,7 +423,7 @@ public any NativeOld_HasAbility(Handle plugin, int params)
 	return false;
 }
 
-public any NativeOld_DoAbility(Handle plugin, int params)
+static any NativeOld_DoAbility(Handle plugin, int params)
 {
 	int client = FindClientOfBossIndex(GetNativeCell(1));
 	if(client != -1)
@@ -437,7 +437,7 @@ public any NativeOld_DoAbility(Handle plugin, int params)
 	return 0;
 }
 
-public any NativeOld_GetAbilityArgument(Handle plugin, int params)
+static any NativeOld_GetAbilityArgument(Handle plugin, int params)
 {
 	int value = GetNativeCell(5);
 	int client = FindClientOfBossIndex(GetNativeCell(1));
@@ -455,7 +455,7 @@ public any NativeOld_GetAbilityArgument(Handle plugin, int params)
 	return value;
 }
 
-public any NativeOld_GetAbilityArgumentFloat(Handle plugin, int params)
+static any NativeOld_GetAbilityArgumentFloat(Handle plugin, int params)
 {
 	float value = GetNativeCell(5);
 	int client = FindClientOfBossIndex(GetNativeCell(1));
@@ -473,7 +473,7 @@ public any NativeOld_GetAbilityArgumentFloat(Handle plugin, int params)
 	return value;
 }
 
-public any NativeOld_GetAbilityArgumentString(Handle plugin, int params)
+static any NativeOld_GetAbilityArgumentString(Handle plugin, int params)
 {
 	int size = GetNativeCell(6);
 	char[] buffer = new char[size];
@@ -493,7 +493,7 @@ public any NativeOld_GetAbilityArgumentString(Handle plugin, int params)
 	return SetNativeString(5, buffer, size);
 }
 
-public any NativeOld_GetArgNamedI(Handle plugin, int params)
+static any NativeOld_GetArgNamedI(Handle plugin, int params)
 {
 	int value = GetNativeCell(5);
 	int client = FindClientOfBossIndex(GetNativeCell(1));
@@ -508,7 +508,7 @@ public any NativeOld_GetArgNamedI(Handle plugin, int params)
 	return value;
 }
 
-public any NativeOld_GetArgNamedF(Handle plugin, int params)
+static any NativeOld_GetArgNamedF(Handle plugin, int params)
 {
 	float value = GetNativeCell(5);
 	int client = FindClientOfBossIndex(GetNativeCell(1));
@@ -523,7 +523,7 @@ public any NativeOld_GetArgNamedF(Handle plugin, int params)
 	return value;
 }
 
-public any NativeOld_GetArgNamedS(Handle plugin, int params)
+static any NativeOld_GetArgNamedS(Handle plugin, int params)
 {
 	int size = GetNativeCell(6);
 	char[] buffer = new char[size];
@@ -540,7 +540,7 @@ public any NativeOld_GetArgNamedS(Handle plugin, int params)
 	return SetNativeString(5, buffer, size);
 }
 
-public any NativeOld_GetDamage(Handle plugin, int params)
+static any NativeOld_GetDamage(Handle plugin, int params)
 {
 	int client = GetNativeCell(1);
 	if(client < 1 || client > MaxClients || Client(client).IsBoss || !IsClientInGame(client))
@@ -549,7 +549,7 @@ public any NativeOld_GetDamage(Handle plugin, int params)
 	return Client(client).TotalDamage;
 }
 
-public any NativeOld_GetFF2flags(Handle plugin, int params)
+static any NativeOld_GetFF2flags(Handle plugin, int params)
 {
 	int client = GetNativeCell(1);
 	if(client < 0 || client >= MAXTF2PLAYERS)
@@ -601,7 +601,7 @@ public any NativeOld_GetFF2flags(Handle plugin, int params)
 	return flags;
 }
 
-public any NativeOld_SetFF2flags(Handle plugin, int params)
+static any NativeOld_SetFF2flags(Handle plugin, int params)
 {
 	int client = GetNativeCell(1);
 	if(client < 0 || client >= MAXTF2PLAYERS)
@@ -632,7 +632,7 @@ public any NativeOld_SetFF2flags(Handle plugin, int params)
 	return 0;
 }
 
-public any NativeOld_GetQueuePoints(Handle plugin, int params)
+static any NativeOld_GetQueuePoints(Handle plugin, int params)
 {
 	int client = GetNativeCell(1);
 	if(client < 0 || client >= MAXTF2PLAYERS)
@@ -641,7 +641,7 @@ public any NativeOld_GetQueuePoints(Handle plugin, int params)
 	return Client(client).Queue;
 }
 
-public any NativeOld_SetQueuePoints(Handle plugin, int params)
+static any NativeOld_SetQueuePoints(Handle plugin, int params)
 {
 	int client = GetNativeCell(1);
 	if(client < 0 || client >= MAXTF2PLAYERS)
@@ -656,7 +656,7 @@ public any NativeOld_SetQueuePoints(Handle plugin, int params)
 	return 0;
 }
 
-public any NativeOld_GetSpecialKV(Handle plugin, int params)
+static any NativeOld_GetSpecialKV(Handle plugin, int params)
 {
 	int index = GetNativeCell(1);
 	if(index != -1)
@@ -699,12 +699,12 @@ public any NativeOld_GetSpecialKV(Handle plugin, int params)
 	return INVALID_HANDLE;
 }
 
-public void NativeOld_DeleteHandle(Handle handle)
+static void NativeOld_DeleteHandle(Handle handle)
 {
 	delete handle;
 }
 
-public any NativeOld_StartMusic(Handle plugin, int params)
+static any NativeOld_StartMusic(Handle plugin, int params)
 {
 	{
 		char buffer[64];
@@ -733,7 +733,7 @@ public any NativeOld_StartMusic(Handle plugin, int params)
 	return 0;
 }
 
-public any NativeOld_StopMusic(Handle plugin, int params)
+static any NativeOld_StopMusic(Handle plugin, int params)
 {
 	int client = GetNativeCell(1);
 	if(client < 1)
@@ -756,7 +756,7 @@ public any NativeOld_StopMusic(Handle plugin, int params)
 	return 0;
 }
 
-public any NativeOld_RandomSound(Handle plugin, int params)
+static any NativeOld_RandomSound(Handle plugin, int params)
 {
 	SoundEnum sound;
 	sound.Default();
@@ -781,7 +781,7 @@ public any NativeOld_RandomSound(Handle plugin, int params)
 	return success;
 }
 
-public any NativeOld_EmitVoiceToAll(Handle plugin, int params)
+static any NativeOld_EmitVoiceToAll(Handle plugin, int params)
 {
 	int size;
 	GetNativeStringLength(1, size);
@@ -836,7 +836,7 @@ public any NativeOld_EmitVoiceToAll(Handle plugin, int params)
 	return 0;
 }
 
-public any NativeOld_GetClientGlow(Handle plugin, int params)
+static any NativeOld_GetClientGlow(Handle plugin, int params)
 {
 	int client = GetNativeCell(1);
 	if(client < 1 || client > MaxClients || !IsClientInGame(client))
@@ -849,7 +849,7 @@ public any NativeOld_GetClientGlow(Handle plugin, int params)
 	return duration;
 }
 
-public any NativeOld_SetClientGlow(Handle plugin, int params)
+static any NativeOld_SetClientGlow(Handle plugin, int params)
 {
 	int client = GetNativeCell(1);
 	if(client >= 0 && client < MAXTF2PLAYERS)
@@ -872,7 +872,7 @@ public any NativeOld_SetClientGlow(Handle plugin, int params)
 	return 0;
 }
 
-public any NativeOld_GetClientShield(Handle plugin, int params)
+static any NativeOld_GetClientShield(Handle plugin, int params)
 {
 	int client = GetNativeCell(1);
 	if(client > 0 && client <= MaxClients && IsClientInGame(client))
@@ -895,12 +895,12 @@ public any NativeOld_GetClientShield(Handle plugin, int params)
 	return -1.0;
 }
 
-public any NativeOld_SetClientShield(Handle plugin, int params)
+static any NativeOld_SetClientShield(Handle plugin, int params)
 {
 	return 0;
 }
 
-public any NativeOld_RemoveClientShield(Handle plugin, int params)
+static any NativeOld_RemoveClientShield(Handle plugin, int params)
 {
 	int client = GetNativeCell(1);
 	if(client > 0 && client <= MaxClients && IsClientInGame(client))
@@ -923,7 +923,7 @@ public any NativeOld_RemoveClientShield(Handle plugin, int params)
 	return -1.0;
 }
 
-public any NativeOld_LogError(Handle plugin, int params)
+static any NativeOld_LogError(Handle plugin, int params)
 {
 	char buffer[256];
 	FormatNativeString(0, 1, 2, sizeof(buffer), _, buffer);
@@ -931,22 +931,22 @@ public any NativeOld_LogError(Handle plugin, int params)
 	return 0;
 }
 
-public any NativeOld_Debug(Handle plugin, int params)
+static any NativeOld_Debug(Handle plugin, int params)
 {
 	return Cvar[Debugging].BoolValue;
 }
 
-public any NativeOld_SetCheats(Handle plugin, int params)
+static any NativeOld_SetCheats(Handle plugin, int params)
 {
 	return 0;
 }
 
-public any NativeOld_GetCheats(Handle plugin, int params)
+static any NativeOld_GetCheats(Handle plugin, int params)
 {
 	return true;
 }
 
-public any NativeOld_MakeBoss(Handle plugin, int params)
+static any NativeOld_MakeBoss(Handle plugin, int params)
 {
 	int client = GetNativeCell(1);
 	if(client > 0 && client <= MaxClients && IsClientInGame(client))
@@ -986,33 +986,23 @@ public any NativeOld_MakeBoss(Handle plugin, int params)
 	return 0;
 }
 
-public any NativeOld_ChooseBoss(Handle plugin, int params)
+static any NativeOld_ChooseBoss(Handle plugin, int params)
 {
 	return false;
 }
 
-public any NativeOld_VSHIsVSHMap(Handle plugin, int params)
+static any NativeOld_VSHIsVSHMap(Handle plugin, int params)
 {
 	return Enabled;
 }
 
-public any NativeOld_VSHGetHale(Handle plugin, int params)
+static any NativeOld_VSHGetHale(Handle plugin, int params)
 {
 	int client = FindClientOfBossIndex(0);
 	return client == -1 ? client : GetClientUserId(client);
 }
 
-public any NativeOld_VSHGetTeam(Handle plugin, int params)
-{
-	int team = TFTeam_Blue;
-	int client = FindClientOfBossIndex(0);
-	if(client != -1)
-		team = GetClientTeam(client);
-	
-	return team;
-}
-
-public any NativeOld_VSHGetSpecial(Handle plugin, int params)
+static any NativeOld_VSHGetSpecial(Handle plugin, int params)
 {
 	int special;
 	int client = FindClientOfBossIndex(0);
@@ -1022,7 +1012,7 @@ public any NativeOld_VSHGetSpecial(Handle plugin, int params)
 	return special;
 }
 
-public any NativeOld_VSHGetHealth(Handle plugin, int params)
+static any NativeOld_VSHGetHealth(Handle plugin, int params)
 {
 	int client = FindClientOfBossIndex(0);
 	if(client != -1)
@@ -1031,7 +1021,7 @@ public any NativeOld_VSHGetHealth(Handle plugin, int params)
 	return 0;
 }
 
-public any NativeOld_VSHGetHealthMax(Handle plugin, int params)
+static any NativeOld_VSHGetHealthMax(Handle plugin, int params)
 {
 	int client = FindClientOfBossIndex(0);
 	if(client != -1)
@@ -1040,7 +1030,7 @@ public any NativeOld_VSHGetHealthMax(Handle plugin, int params)
 	return 0;
 }
 
-public any NativeOld_VSHGetRoundState(Handle plugin, int params)
+static any NativeOld_VSHGetRoundState(Handle plugin, int params)
 {
 	switch(GameRules_GetRoundState())
 	{
@@ -1060,7 +1050,7 @@ public any NativeOld_VSHGetRoundState(Handle plugin, int params)
 static char AbilityCache[13][64];
 static char PluginCache[13][64];
 
-public any NativeOld_FF2Data(Handle plugin, int params)
+static any NativeOld_FF2Data(Handle plugin, int params)
 {
 	int boss = GetNativeCell(1);
 	if(boss < 0 || boss > 12)
@@ -1077,17 +1067,17 @@ public any NativeOld_FF2Data(Handle plugin, int params)
 	return boss;
 }
 
-public any NativeOld_FF2DataBoss(Handle plugin, int params)
+static any NativeOld_FF2DataBoss(Handle plugin, int params)
 {
 	return GetNativeCell(1);
 }
 
-public any NativeOld_FF2DataClient(Handle plugin, int params)
+static any NativeOld_FF2DataClient(Handle plugin, int params)
 {
 	return FindClientOfBossIndex(GetNativeCell(1));
 }
 
-public any NativeOld_FF2DataArgI(Handle plugin, int params)
+static any NativeOld_FF2DataArgI(Handle plugin, int params)
 {
 	int boss = GetNativeCell(1);
 	int value = GetNativeCell(3);
@@ -1105,7 +1095,7 @@ public any NativeOld_FF2DataArgI(Handle plugin, int params)
 	return value;
 }
 
-public any NativeOld_FF2DataArgF(Handle plugin, int params)
+static any NativeOld_FF2DataArgF(Handle plugin, int params)
 {
 	int boss = GetNativeCell(1);
 	float value = GetNativeCell(3);
@@ -1123,7 +1113,7 @@ public any NativeOld_FF2DataArgF(Handle plugin, int params)
 	return value;
 }
 
-public any NativeOld_FF2DataArgB(Handle plugin, int params)
+static any NativeOld_FF2DataArgB(Handle plugin, int params)
 {
 	int boss = GetNativeCell(1);
 	bool value = GetNativeCell(3);
@@ -1141,7 +1131,7 @@ public any NativeOld_FF2DataArgB(Handle plugin, int params)
 	return value;
 }
 
-public any NativeOld_FF2DataArgS(Handle plugin, int params)
+static any NativeOld_FF2DataArgS(Handle plugin, int params)
 {
 	int size = GetNativeCell(4);
 	char[] buffer = new char[size];
@@ -1162,7 +1152,7 @@ public any NativeOld_FF2DataArgS(Handle plugin, int params)
 	return boss;
 }
 
-public any NativeOld_FF2DataHasAbility(Handle plugin, int params)
+static any NativeOld_FF2DataHasAbility(Handle plugin, int params)
 {
 	int boss = GetNativeCell(1);
 	if(boss >= 0 && boss < 13)

--- a/addons/sourcemod/scripting/freak_fortress_2/preference.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/preference.sp
@@ -295,7 +295,7 @@ int Preference_PickBoss(int client, int team = -1)
 	return special;
 }
 
-public Action Preference_BossMenuLegacy(int client, int args)
+static Action Preference_BossMenuLegacy(int client, int args)
 {
 	FReplyToCommand(client, "%t", "Legacy Boss Menu Command");
 	
@@ -309,7 +309,7 @@ public Action Preference_BossMenuLegacy(int client, int args)
 	return Plugin_Handled;
 }
 
-public Action Preference_BossMenuCmd(int client, int args)
+static Action Preference_BossMenuCmd(int client, int args)
 {
 	if(GetCmdReplySource() == SM_REPLY_TO_CONSOLE)
 	{
@@ -700,7 +700,7 @@ static void BossMenu(int client)
 	}
 }
 
-public int Preference_BossMenuH(Menu menu, MenuAction action, int client, int choice)
+static int Preference_BossMenuH(Menu menu, MenuAction action, int client, int choice)
 {
 	switch(action)
 	{
@@ -968,7 +968,7 @@ static void CreateParty(int client)
 	menu.Display(client, MENU_TIME_FOREVER);
 }
 
-public int Preference_CreatePartyH(Menu menu, MenuAction action, int client, int choice)
+static int Preference_CreatePartyH(Menu menu, MenuAction action, int client, int choice)
 {
 	switch(action)
 	{
@@ -1055,7 +1055,7 @@ static bool PartyMenu(int client)
 	return true;
 }
 
-public int Preference_PartyMenuH(Menu menu, MenuAction action, int client, int choice)
+static int Preference_PartyMenuH(Menu menu, MenuAction action, int client, int choice)
 {
 	switch(action)
 	{
@@ -1163,7 +1163,7 @@ public int Preference_PartyMenuH(Menu menu, MenuAction action, int client, int c
 	return 0;
 }
 
-public int Preference_PartyInviteH(Menu menu, MenuAction action, int client, int choice)
+static int Preference_PartyInviteH(Menu menu, MenuAction action, int client, int choice)
 {
 	switch(action)
 	{
@@ -1255,7 +1255,7 @@ static bool InviteMenu(int client)
 	return false;
 }
 
-public int Preference_InviteMenuH(Menu menu, MenuAction action, int client, int choice)
+static int Preference_InviteMenuH(Menu menu, MenuAction action, int client, int choice)
 {
 	switch(action)
 	{
@@ -1476,7 +1476,7 @@ int Preference_GetBossQueue(int[] players, int maxsize, bool display, int team =
 	return size;
 }
 
-public int Preference_BossQueueSort(int[] elem1, int[] elem2, const int[][] array, Handle hndl)
+static int Preference_BossQueueSort(int[] elem1, int[] elem2, const int[][] array, Handle hndl)
 {
 	if(elem1[1] > elem2[1])
 		return -1;
@@ -1487,7 +1487,7 @@ public int Preference_BossQueueSort(int[] elem1, int[] elem2, const int[][] arra
 	return (elem1[0] > elem2[0]) ? 1 : -1;
 }
 
-public Action Preference_ForceBossCmd(int client, int args)
+static Action Preference_ForceBossCmd(int client, int args)
 {
 	if(args)
 	{
@@ -1566,7 +1566,7 @@ static void ForceBossMenu(int client, int item)
 	menu.DisplayAt(client, item/7*7, MENU_TIME_FOREVER);
 }
 
-public int Preference_ForceBossMenuH(Menu menu, MenuAction action, int client, int choice)
+static int Preference_ForceBossMenuH(Menu menu, MenuAction action, int client, int choice)
 {
 	switch(action)
 	{
@@ -1608,7 +1608,7 @@ static int GetBlacklistCount(int client, int charset)
 	return count;
 }
 
-public void Preference_DisplayBosses(DataPack pack)
+static void Preference_DisplayBosses(DataPack pack)
 {
 	pack.Reset();
 	int client = GetClientOfUserId(pack.ReadCell());
@@ -1816,7 +1816,7 @@ bool Preference_HasDifficulties()
 	return view_as<bool>(Difficulties);
 }
 
-public Action Preference_DifficultyMenuCmd(int client, int args)
+static Action Preference_DifficultyMenuCmd(int client, int args)
 {
 	if(!Preference_HasDifficulties())
 		return Plugin_Continue;
@@ -2028,7 +2028,7 @@ static void DifficultyMenu(int client, const char[] name = NULL_STRING)
 	}
 }
 
-public int Preference_DifficultyMenuH(Menu menu, MenuAction action, int client, int choice)
+static int Preference_DifficultyMenuH(Menu menu, MenuAction action, int client, int choice)
 {
 	switch(action)
 	{
@@ -2068,7 +2068,7 @@ public int Preference_DifficultyMenuH(Menu menu, MenuAction action, int client, 
 	return 0;
 }
 
-public int Preference_DifficultyMenuItemH(Menu menu, MenuAction action, int client, int choice)
+static int Preference_DifficultyMenuItemH(Menu menu, MenuAction action, int client, int choice)
 {
 	switch(action)
 	{

--- a/addons/sourcemod/scripting/freak_fortress_2/sdkhooks.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/sdkhooks.sp
@@ -97,7 +97,7 @@ public void OnEntityDestroyed(int entity)
 	DHook_EntityDestoryed();
 }
 
-public Action SDKHook_TakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
+static Action SDKHook_TakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
 {
 	CritType crit = (damagetype & DMG_CRIT) ? CritType_Crit : CritType_None;
 	return TF2_OnTakeDamage(victim, attacker, inflictor, damage, damagetype, weapon, damageForce, damagePosition, damagecustom, crit);
@@ -428,7 +428,7 @@ public Action TF2_OnTakeDamage(int victim, int &attacker, int &inflictor, float 
 	return Plugin_Continue;
 }
 
-public void SDKHook_TakeDamagePost(int victim, int attacker, int inflictor, float damage, int damagetype, int weapon, const float damageForce[3], const float damagePosition[3], int damagecustom)
+static void SDKHook_TakeDamagePost(int victim, int attacker, int inflictor, float damage, int damagetype, int weapon, const float damageForce[3], const float damagePosition[3], int damagecustom)
 {
 	if(Client(victim).IsBoss)
 	{
@@ -439,12 +439,12 @@ public void SDKHook_TakeDamagePost(int victim, int attacker, int inflictor, floa
 	}
 }
 
-public void SDKHook_SwitchPost(int client, int weapon)
+static void SDKHook_SwitchPost(int client, int weapon)
 {
 	Weapons_OnWeaponSwitch(client, weapon);
 }
 
-public Action SDKHook_NormalSHook(int clients[MAXPLAYERS], int &numClients, char sample[PLATFORM_MAX_PATH], int &entity, int &channel, float &volume, int &level, int &pitch, int &flags, char soundEntry[PLATFORM_MAX_PATH], int &seed)
+static Action SDKHook_NormalSHook(int clients[MAXPLAYERS], int &numClients, char sample[PLATFORM_MAX_PATH], int &entity, int &channel, float &volume, int &level, int &pitch, int &flags, char soundEntry[PLATFORM_MAX_PATH], int &seed)
 {
 	if(entity > 0 && entity <= MaxClients && ((channel == SNDCHAN_VOICE && StrContains(sample, "ambient_mp3", false) == -1) || (channel == SNDCHAN_STATIC && !StrContains(sample, "vo", false))))
 	{
@@ -534,7 +534,7 @@ public Action SDKHook_NormalSHook(int clients[MAXPLAYERS], int &numClients, char
 	return Plugin_Continue;
 }
 
-public Action SDKHook_HealthTouch(int entity, int client)
+static Action SDKHook_HealthTouch(int entity, int client)
 {
 	if(client > 0 && client <= MaxClients && (Client(client).Minion || (Client(client).IsBoss && (Client(client).Pickups != 1 && Client(client).Pickups < 3))))
 		return Plugin_Handled;
@@ -542,7 +542,7 @@ public Action SDKHook_HealthTouch(int entity, int client)
 	return Plugin_Continue;
 }
 
-public Action SDKHook_AmmoTouch(int entity, int client)
+static Action SDKHook_AmmoTouch(int entity, int client)
 {
 	if(client > 0 && client <= MaxClients && (Client(client).Minion || (Client(client).IsBoss && Client(client).Pickups < 2)))
 		return Plugin_Handled;
@@ -550,7 +550,7 @@ public Action SDKHook_AmmoTouch(int entity, int client)
 	return Plugin_Continue;
 }
 
-public Action SDKHook_TimerSpawn(int entity)
+static Action SDKHook_TimerSpawn(int entity)
 {
 	DispatchKeyValue(entity, "auto_countdown", "0");
 	return Plugin_Continue;

--- a/addons/sourcemod/scripting/freak_fortress_2/stocks.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/stocks.sp
@@ -70,6 +70,9 @@ SectionType GetSectionType(const char[] buffer)
 	if(StrEqual(buffer, "download"))
 		return Section_Download;
 
+	if(!StrContains(buffer, "filenet"))
+		return Section_FileNet;
+
 	if(!StrContains(buffer, "map_"))
 		return Section_Map;
 

--- a/addons/sourcemod/scripting/freak_fortress_2/weapons.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/weapons.sp
@@ -90,7 +90,7 @@ stock void Weapons_LibraryRemoved(const char[] name)
 	#endif
 }
 
-public Action Weapons_DebugRefresh(int client, int args)
+static Action Weapons_DebugRefresh(int client, int args)
 {
 	TF2_RemoveAllItems(client);
 	
@@ -104,7 +104,7 @@ public Action Weapons_DebugRefresh(int client, int args)
 	return Plugin_Handled;
 }
 
-public Action Weapons_DebugReload(int client, int args)
+static Action Weapons_DebugReload(int client, int args)
 {
 	if(Weapons_ConfigsExecuted(true))
 	{
@@ -121,7 +121,7 @@ public Action Weapons_DebugReload(int client, int args)
 	return Plugin_Handled;
 }
 
-public Action Weapons_ChangeMenuCmd(int client, int args)
+static Action Weapons_ChangeMenuCmd(int client, int args)
 {
 	if(client)
 	{
@@ -222,7 +222,7 @@ void Weapons_ChangeMenu(int client, int time = MENU_TIME_FOREVER)
 	}
 }
 
-public int Weapons_ChangeMenuH(Menu menu, MenuAction action, int client, int choice)
+static int Weapons_ChangeMenuH(Menu menu, MenuAction action, int client, int choice)
 {
 	switch(action)
 	{
@@ -682,7 +682,7 @@ void Weapons_OnInventoryApplication(int userid)
 	RequestFrame(Weapons_OnInventoryApplicationFrame, userid);
 }
 
-public void Weapons_OnInventoryApplicationFrame(int userid)
+static void Weapons_OnInventoryApplicationFrame(int userid)
 {
 	int client = GetClientOfUserId(userid);
 	if(client)
@@ -789,12 +789,12 @@ void Weapons_EntityCreated(int entity, const char[] classname)
 		SDKHook(entity, SDKHook_SpawnPost, Weapons_Spawn);
 }
 
-public void Weapons_Spawn(int entity)
+static void Weapons_Spawn(int entity)
 {
 	RequestFrame(Weapons_SpawnFrame, EntIndexToEntRef(entity));
 }
 
-public void Weapons_SpawnFrame(int ref)
+static void Weapons_SpawnFrame(int ref)
 {
 	if(!WeaponCfg)
 		return;

--- a/addons/sourcemod/scripting/include/ff2r.inc
+++ b/addons/sourcemod/scripting/include/ff2r.inc
@@ -165,6 +165,18 @@ native bool FF2R_GetClientHud(int client);
 native void FF2R_SetClientHud(int client, bool status);
 
 /**
+ * Sets if the client can see HUDs
+ * 
+ * @param client	Client index, 0 to only check for download table
+ * @param file		Filepath of file
+ * 
+ * @error		Invalid client index or client is not in game
+ * 
+ * @return		True if on the download table or client has the file through late downloads, false otherwise
+ */
+native bool FF2R_ClientHasFile(int client, const char[] file);
+
+/**
  * Called when a player spawns, dies, disconnects, etc.
  * 
  * @note		Players counted as minions aren't counted

--- a/addons/sourcemod/translations/ff2_rewrite.phrases.txt
+++ b/addons/sourcemod/translations/ff2_rewrite.phrases.txt
@@ -545,6 +545,10 @@
 	{
 		"en"		"View Playlist"
 	}
+	"Music Downloading"
+	{
+		"en"		"Downloading"
+	}
 	
 	"Difficulty Menu"
 	{

--- a/scripts/optional.sh
+++ b/scripts/optional.sh
@@ -6,3 +6,4 @@ wget "https://raw.githubusercontent.com/nosoop/SM-TFCustomWeaponsX/master/script
 wget "https://raw.githubusercontent.com/nosoop/SM-TFUtils/master/scripting/include/tf2utils.inc"
 wget "https://raw.githubusercontent.com/Flyflo/SM-Goomba-Stomp/master/addons/sourcemod/scripting/include/goomba.inc"
 wget "https://raw.githubusercontent.com/ExperimentFailed/SteamWorks/master/Pawn/includes/SteamWorks.inc"
+wget "https://raw.githubusercontent.com/Batfoxkid/File-Network/main/scripting/include/filenetwork.inc"


### PR DESCRIPTION
Adds support for using [File Network](https://github.com/Batfoxkid/File-Network) as an alternative for boss downloads, especially sound files. This will help in some cases where you may need to reduce entry downloads or things that may be optional like alternative music or catch phrases. Any file is supported but models are not handled by FF2 or anything that does not play from FF2. A new native `FF2R_ClientHasFile` is available for these cases.

Automatically checks in sound section files whether to play the sound (or display an overlay) to a player.

The example below shows making the music file download in-game, since it's used by sound_bgm, it'll wait until the player has the sound before playing the music.
```diff
	"download"
	{
		"models/freak_fortress_2/gentlespy/the_gentlespy_v3"			"mdl"
		"materials/freak_fortress_2/gentlespy_tex/stylish_spy_blue"		"mat"
		"materials/freak_fortress_2/gentlespy_tex/stylish_spy_blue_invun"	"mat"
		"materials/freak_fortress_2/gentlespy_tex/stylish_spy_red"		"mat"
		"materials/freak_fortress_2/gentlespy_tex/stylish_spy_red_invun"	"mat"
		"materials/freak_fortress_2/gentlespy_tex/stylish_spy_normal.vtf"	""
-		"sound/freak_fortress_2/gentlespy/gentle_music.mp3"			""
	}
+	"filenetwork"
+	{
+		"sound/freak_fortress_2/gentlespy/gentle_music.mp3"			""
+	}
```