### PR TITLE
Use `+inspect` instead of ducking to show ability's description

### DIFF
--- a/addons/sourcemod/scripting/ff2r_epic_abilities.sp
+++ b/addons/sourcemod/scripting/ff2r_epic_abilities.sp
@@ -260,7 +260,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 public void OnPluginStart()
 {
 	LoadTranslations("ff2_rewrite.phrases");
-	if(!TranslationPhraseExists("Boss Weapon Pickups"))
+	if(!TranslationPhraseExists("Boss AMS Description"))
 		SetFailState("Translation file \"ff2_rewrite.phrases\" is outdated");
 	
 	GameData gamedata = new GameData("sm-tf2.games");
@@ -469,6 +469,9 @@ public void FF2R_OnBossCreated(int client, BossData boss, bool setup)
 			if(ability.IsMyPlugin())
 			{
 				HasAbility[client] = -1;
+				
+				PrintCenterText(client, "%t", "Boss AMS Description");
+				PrintToChat(client, "%t", "Boss AMS Description");
 				
 				bool medic;
 				int buttons;

--- a/addons/sourcemod/translations/ff2_rewrite.phrases.txt
+++ b/addons/sourcemod/translations/ff2_rewrite.phrases.txt
@@ -633,6 +633,10 @@
 	{
 		"en"		"Weapon Pickups - Pickup non-melee weapons to use them in combat"
 	}
+	"Boss AMS Description"
+	{
+		"en"		"AMS - Press inspect key to see ability's description"
+	}
 	"Button E"
 	{
 		"en"		"Call for Medic"


### PR DESCRIPTION
- Originally, description in AMS is appeared while ducking. But this way isn't good because ducking is very frequent in tf2(ex: duck-jump). As a result, AMS HUD is very messy to looking.
- So, I changed that to use `+inspect`(Default: F).