### PR TITLE
Fix for FF2 not recognizing workshop maps

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -353,6 +353,7 @@ public void OnConfigsExecuted()
 {
 	char mapname[64];
 	GetCurrentMap(mapname, sizeof(mapname));
+	GetMapDisplayName(mapname, mapname, sizeof(mapname));
 	if(Configs_SetMap(mapname))
 	{
 		Charset = Cvar[NextCharset].IntValue;

--- a/addons/sourcemod/scripting/freak_fortress_2/bosses.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/bosses.sp
@@ -65,6 +65,7 @@ static Action Bosses_ReloadCharsetCmd(int client, int args)
 {
 	char mapname[64];
 	GetCurrentMap(mapname, sizeof(mapname));
+	GetMapDisplayName(mapname, mapname, sizeof(mapname));
 	Bosses_BuildPacks(Charset, mapname);
 	return Plugin_Handled;
 }

--- a/addons/sourcemod/scripting/freak_fortress_2/gamemode.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/gamemode.sp
@@ -31,6 +31,7 @@ void Gamemode_MapInit()
 {
 	char mapname[64];
 	GetCurrentMap(mapname, sizeof(mapname));
+	GetMapDisplayName(mapname, mapname, sizeof(mapname));
 	if(Configs_MapIsGamemode(mapname))
 	{
 		bool addMaster;


### PR DESCRIPTION
Fixes FF2 never loading on workshop maps by adding GetMapDisplayName.