### PR TITLE
Fix Pack Vote for workshop map

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2/configs.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/configs.sp
@@ -148,10 +148,15 @@ bool Configs_SetMap(const char[] mapname)
 
 static void Configs_StartVote(ConVar cvar, const char[] oldValue, const char[] newValue)
 {
-	if(!VotedPack && Cvar[PackVotes].BoolValue && Bosses_GetCharsetLength() > 1 && Configs_MapIsGamemode(newValue))
+	if(!VotedPack && Cvar[PackVotes].BoolValue && Bosses_GetCharsetLength() > 1)
 	{
-		VotedPack = true;
-		RequestFrame(Configs_PackVoteFrame);
+		char mapname[64];
+		GetMapDisplayName(newValue, mapname, sizeof(mapname));
+		if(Configs_MapIsGamemode(mapname))
+		{
+			VotedPack = true;
+			RequestFrame(Configs_PackVoteFrame);
+		}
 	}
 }
 


### PR DESCRIPTION
- #252 allow FF2 to load workshop map. However, the bug where a pack vote was not created when a Workshop map was selected as the next map still remained.
- Thanks to @synthakii for letting me know about this issue.