### PR TITLE
Fix weapon attribute logic is not working properly

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2/weapons.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/weapons.sp
@@ -713,7 +713,14 @@ static void Weapons_SpawnFrame(int ref)
 				
 				if(TF2ED_GetAttributeName(attrib, key, sizeof(key)))
 				{
-					Attrib_Set(entity, key, StringToFloat(value));
+					if(value[0] == 'R')
+					{
+						Attrib_Remove(entity, key);
+					}
+					else
+					{
+						Attrib_Set(entity, key, StringToFloat(value));
+					}
 				}
 				else
 				{
@@ -742,8 +749,16 @@ static void Weapons_SpawnFrame(int ref)
 
 				if(attributeValue.tag == KeyValType_Value)
 				{
-					if(!Attrib_SetString(entity, key, attributeValue.data))
-						LogError("[Config] Attribute '%s' is invalid/unloaded in weapons config", key);
+					// Some attributes have string value. So check size of value.
+					if(attributeValue.data[0] == 'R' && attributeValue.size < 2)
+					{
+						Attrib_Remove(entity, key);
+					}
+					else
+					{
+						if(!Attrib_SetString(entity, key, attributeValue.data))
+							LogError("[Config] Attribute '%s' is invalid/unloaded in weapons config", key);
+					}
 				}
 			}
 

--- a/addons/sourcemod/scripting/freak_fortress_2/weapons.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/weapons.sp
@@ -510,7 +510,10 @@ void Weapons_ShowChanges(int client, int entity)
 				{
 					int attrib = TF2ED_TranslateAttributeNameToDefinitionIndex(key);
 					if(attrib != -1)
+					{
+						strcopy(value, sizeof(value), attributeValue.data);
 						PrintThisAttrib(client, attrib, value, type, desc, buffer2, key, length);
+					}
 				}
 			}
 


### PR DESCRIPTION
- Re-Added removing attribute (e.g. `"damage penalty"	"R"`)
- Fixed wrong native attribute value is showing in `ff2weapons`