### PR TITLE
Fix Sickle Climb Values

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2/customattrib.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/customattrib.sp
@@ -947,9 +947,9 @@ void CustomAttrib_CalcIsAttackCritical(int client, int weapon)
 			{
 				if(vec[0] > -30.0)
 				{
-					TR_GetEndPosition(vec);
+					TR_GetEndPosition(vec, trace);
 
-					if(GetVectorDistance(pos, vec, true) < 3868156.0)
+					if(GetVectorDistance(pos, vec, true) < 10000.0)
 					{
 						GetEntPropVector(client, Prop_Data, "m_vecVelocity", vec);
 						vec[2] = 600.0;


### PR DESCRIPTION
Adjusted the sickle climb values to work when applied to regular weapons, also added the 1 damage by default (it's not changed anywhere) as per the description.