### PR TITLE
Fix not applying blastjumpstate when superjump

### DIFF
--- a/addons/sourcemod/scripting/ff2r_default_abilities.sp
+++ b/addons/sourcemod/scripting/ff2r_default_abilities.sp
@@ -1006,10 +1006,10 @@ public void OnPlayerRunCmdPost(int client, int buttons, int impulse, const float
 							
 							TeleportEntity(client, _, _, velocity);
 							
+							SetEntityFlags(client, GetEntityFlags(client) & ~FL_ONGROUND);
 							SetEntProp(client, Prop_Send, "m_bJumping", true);
 
 							SDKCall_SetJumpBlastState(client, TF_PLAYER_ENEMY_BLASTED_ME);
-							TF2_AddCondition(client, TFCond_BlastJumping, _, client);
 							
 							if(ability.GetString("slot", buffer, sizeof(buffer)))
 								FF2R_EmitBossSoundToAll("sound_ability", client, buffer, client, _, SNDLEVEL_TRAFFIC);


### PR DESCRIPTION
For some unknown reason, adding `TFCond_BlastJumping` condition disrupts applying `m_iBlastJumpState`.