### PR TITLE
fix crazy rank health

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2/ranking.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/ranking.sp
@@ -56,7 +56,7 @@ int Ranking_ApplyEffects(int client, float &multi)
 	multi = Ranking_GetHealthMulti(rank);
 	if(multi != 1.0)
 	{
-		Client(client).MaxHealth *= multi;
+		Client(client).MaxHealth = RoundToCeil(Client(client).MaxHealth * multi);
 
 		if(IsPlayerAlive(client))
 		{


### PR DESCRIPTION
- fixes rank glitching out due to SetEntityHealth accepting only "int", but MaxHealth property being "float"