### PR TITLE
Fix Wrong Companion Choosing

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2/preference.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/preference.sp
@@ -1459,11 +1459,11 @@ int Preference_GetCompanion(int client, int special, int team, int &consume, int
 
 			players[total++] = player;
 
-			if(!Enabled || Preference_DisabledBoss(client, Charset) || !Preference_HasWhitelisted(client, leadSpecial))
+			if(!Enabled || Preference_DisabledBoss(player, Charset) || !Preference_HasWhitelisted(player, leadSpecial))
 				continue;
 			
-			queue[size][1] = Client(client).Queue;
-			queue[size++][0] = client;
+			queue[size][1] = Client(player).Queue;
+			queue[size++][0] = player;
 		}
 	}
 	


### PR DESCRIPTION
- There is a bug that leader is selected as compainion. For example, even if you are selected as a seeman, you might still spawn as a seeldier. without health scailing.