### PR TITLE
Prevent issues when switching player's teams

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2/core/gamemode.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/core/gamemode.sp
@@ -459,7 +459,7 @@ void Gamemode_RoundStart()
 						{
 							SetEntProp(client, Prop_Send, "m_lifeState", 2);
 							ChangeClientTeam(client, MercTeam);
-							TF2Tools_RespawnPlayer(players[i]);
+							TF2Tools_RespawnPlayer(client);
 						}
 						else
 						{

--- a/addons/sourcemod/scripting/freak_fortress_2/core/gamemode.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/core/gamemode.sp
@@ -170,7 +170,7 @@ void Gamemode_RoundSetup()
 					{
 						SetEntProp(players[i], Prop_Send, "m_lifeState", 2);
 						ChangeClientTeam(players[i], team);
-						SetEntProp(players[i], Prop_Send, "m_lifeState", 0);
+						TF2Tools_RespawnPlayer(players[i]);
 						
 						team++;
 						if(team >= maxTeams)
@@ -238,7 +238,7 @@ void Gamemode_RoundSetup()
 					{
 						SetEntProp(players[i], Prop_Send, "m_lifeState", 2);
 						ChangeClientTeam(players[i], MercTeam);
-						SetEntProp(players[i], Prop_Send, "m_lifeState", 0);
+						TF2Tools_RespawnPlayer(players[i]);
 					}
 				}
 				else	// No boss, normal Arena time
@@ -260,7 +260,7 @@ void Gamemode_RoundSetup()
 						{
 							SetEntProp(players[i], Prop_Send, "m_lifeState", 2);
 							ChangeClientTeam(players[i], team);
-							SetEntProp(players[i], Prop_Send, "m_lifeState", 0);
+							TF2Tools_RespawnPlayer(players[i]);
 							
 							team++;
 							if(team >= (TFTeam_Red + Configs_TeamCount()))
@@ -459,7 +459,7 @@ void Gamemode_RoundStart()
 						{
 							SetEntProp(client, Prop_Send, "m_lifeState", 2);
 							ChangeClientTeam(client, MercTeam);
-							SetEntProp(client, Prop_Send, "m_lifeState", 0);
+							TF2Tools_RespawnPlayer(players[i]);
 						}
 						else
 						{


### PR DESCRIPTION
Forcing `m_lifeState` to 0 has always been problematic and prone to causing issues like living spectators or players not appearing in their correct spawn position.

So let's rectify this and do things the orderly way.
