### PR TITLE
Add missing Blitzkrieg material to downloads

### DIFF
--- a/addons/sourcemod/configs/freak_fortress_2/non-default/blitzkrieg.cfg
+++ b/addons/sourcemod/configs/freak_fortress_2/non-default/blitzkrieg.cfg
@@ -1663,6 +1663,7 @@
 	"download"
 	{
 		"models/freak_fortress_2/shadow93/dmedic/d_medic2_fix2"	"mdl"
+		"materials/freak_fortress_2/shadow93/dmedic/medic_red"	"mat"
 		"materials/freak_fortress_2/shadow93/dmedic/eyeball_invun.vmt"	""
 		"materials/freak_fortress_2/shadow93/dmedic/eyeball_l.vmt"	""
 		"materials/freak_fortress_2/shadow93/dmedic/eyeball_r.vmt"	""


### PR DESCRIPTION
This was causing the boss to appear as a normal medic to players.