### PR TITLE
Added FF2R_StopMusic(); and FF2R_PlayMusic(); natives

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2/core/music.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/core/music.sp
@@ -36,6 +36,11 @@ void Music_AddSong(int special, const char[] section, const char[] key)
 	Playlist.PushArray(music);
 }
 
+ArrayList Music_GetPlaylist()
+{
+	return Playlist;
+}
+
 void Music_BossCreated(int boss)
 {
 	SoundEnum sound;

--- a/addons/sourcemod/scripting/freak_fortress_2/core/natives.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/core/natives.sp
@@ -313,12 +313,78 @@ static any Native_SetClientAssist(Handle plugin, int params)
 
 static any Native_StopMusic(Handle plugin, int params)
 {
-	Music_PlaySongToAll();
+	int client = params >= 1 ? GetNativeCell(1) : 0;
+
+	if(client)
+		Music_PlaySongToClient(client);
+	else
+		Music_PlaySongToAll();
+	
 	return 0;
 }
 
 static any Native_PlayMusic(Handle plugin, int params)
 {
-	Music_PlayNextSong();
+	int client   = params >= 1 ? GetNativeCell(1) : 0;
+	int index    = params >= 2 ? GetNativeCell(2) :-1;
+	bool shuffle = params >= 3 ? view_as<bool>(GetNativeCell(3)) : false;
+	
+	if(index >= 0 && index < Music_GetPlaylist().Length)
+	{
+		MusicEnum music;
+		Music_GetPlaylist().GetArray(index, music);
+
+		ConfigMap cfg = Bosses_GetConfig(music.Special);
+		if (!cfg) return 0;
+
+		SoundEnum sound;
+		sound.Default();
+		if(!Bosses_GetSpecificSoundCfg(cfg, music.Section, music.Key, sizeof(music.Key), sound))
+			return 0;
+
+		if(client)
+		{
+			bool prev = Client(client).MusicShuffle;
+			Client(client).MusicShuffle = true;
+			Music_PlaySongToClient(client, sound, music.Special);
+			Client(client).MusicShuffle = prev;
+		}
+		else
+		{
+			for(int i = 1; i <= MaxClients; i++)
+			{
+				if(IsClientInGame(i))
+				{
+					bool prev = Client(i).MusicShuffle;
+					Client(i).MusicShuffle = true;
+					Music_PlaySongToClient(i, sound, music.Special);
+					Client(i).MusicShuffle = prev;
+				}
+			}
+		}
+	}
+	else
+	{
+		if(client)
+		{
+			bool prev = Client(client).MusicShuffle;
+			if(shuffle) Client(client).MusicShuffle = true;
+			Music_PlayNextSong(client);
+			Client(client).MusicShuffle = prev;
+		}
+		else
+		{
+			for(int i = 1; i <= MaxClients; i++)
+			{
+				if(IsClientInGame(i))
+				{
+					bool prev = Client(i).MusicShuffle;
+					if(shuffle) Client(i).MusicShuffle = true;
+					Music_PlayNextSong(i);
+					Client(i).MusicShuffle = prev;
+				}
+			}
+		}
+	}
 	return 0;
 }

--- a/addons/sourcemod/scripting/freak_fortress_2/core/natives.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2/core/natives.sp
@@ -23,6 +23,8 @@ void Native_PluginLoad()
 	CreateNative("FF2R_ClientHasFile", Native_ClientHasFile);
 	CreateNative("FF2R_GetClientAssist", Native_GetClientAssist);
 	CreateNative("FF2R_SetClientAssist", Native_SetClientAssist);
+	CreateNative("FF2R_StopMusic", Native_StopMusic);
+	CreateNative("FF2R_PlayMusic", Native_PlayMusic);
 	
 	RegPluginLibrary("ff2r");
 }
@@ -306,5 +308,17 @@ static any Native_SetClientAssist(Handle plugin, int params)
 	
 	Client(client).Assist = GetNativeCell(2);
 	Client(client).RefreshAt = 0.0;
+	return 0;
+}
+
+static any Native_StopMusic(Handle plugin, int params)
+{
+	Music_PlaySongToAll();
+	return 0;
+}
+
+static any Native_PlayMusic(Handle plugin, int params)
+{
+	Music_PlayNextSong();
 	return 0;
 }

--- a/addons/sourcemod/scripting/include/ff2r.inc
+++ b/addons/sourcemod/scripting/include/ff2r.inc
@@ -328,20 +328,29 @@ stock bool FF2R_EmitBossSoundToAll(const char[] key, int boss, const char[] requ
 }
 
 /**
- *	Stops any currently playing music for all clients.
+ *  If a client isn't specified, stops any currently playing music for all players.
+ *  If a client was specified, stops any currently playing music for that player only.
  *  Does not play any other music after it's called. Best used with FF2R_PlayMusic(); 
  *
+ *  @param client    Client index, 0 for all players
  *	@noreturn
  */
-native void FF2R_StopMusic();
+native void FF2R_StopMusic(int client = 0);
 
 /**
- * If shuffle is disabled, plays the next song of the current boss's bgm's.
- * If shuffle is enabled, plays the next song from any of the boss's bgm's.
+ *  Plays music for all clients or a specific client only.
+ *  If no index is given, plays the next song based on the client's current shuffle state.
+ *  If an index is given, plays that specific music from the playlist.
+ *  If shuffle is disabled, plays the next song of the current boss's bgm's.
+ *  If shuffle is enabled, plays the next song from the playlist.
+ *  Does not permanently change any player's settings.
  *
- * @noreturn
+ *  @param client           Client index, 0 for all players
+ *  @param playlistindex    Specific playlist index to play, -1 for no specific music
+ *  @param shuffle          If true, forces shuffle for this call only
+ *  @noreturn
  */
-native void FF2R_PlayMusic();
+native void FF2R_PlayMusic(int client = 0, int playlistindex = -1, bool shuffle = false);
  
 /**
  *	Below is related to using ConfigMap, though cfgmap is not required for this include, needed for the below

--- a/addons/sourcemod/scripting/include/ff2r.inc
+++ b/addons/sourcemod/scripting/include/ff2r.inc
@@ -328,6 +328,22 @@ stock bool FF2R_EmitBossSoundToAll(const char[] key, int boss, const char[] requ
 }
 
 /**
+ *	Stops any currently playing music for all clients.
+ *  Does not play any other music after it's called. Best used with FF2R_PlayMusic(); 
+ *
+ *	@noreturn
+ */
+native void FF2R_StopMusic();
+
+/**
+ * If shuffle is disabled, plays the next song of the current boss's bgm's.
+ * If shuffle is enabled, plays the next song from any of the boss's bgm's.
+ *
+ * @noreturn
+ */
+native void FF2R_PlayMusic();
+ 
+/**
  *	Below is related to using ConfigMap, though cfgmap is not required for this include, needed for the below
  */
 #if defined CFGMAP_FF2R
@@ -966,5 +982,7 @@ public void __pl_ff2r_SetNTVOptional()
 	MarkNativeAsOptional("FF2R_GetSpecialData");
 	MarkNativeAsOptional("FF2R_GetSpecialCount");
 	MarkNativeAsOptional("FF2R_CreateBoss");
+	MarkNativeAsOptional("FF2R_StopMusic");
+	MarkNativeAsOptional("FF2R_PlayMusic");
 }
 #endif


### PR DESCRIPTION
Added FF2R_StopMusic(); and FF2R_PlayMusic(); natives StopMusic stops any music currently playing for all clients but does not play any other music after its called. PlayMusic restores the music loop that starts when the round starts and makes it so that it plays a random music when called and after that music ends plays another just like the normal loop in ff2r.

Added for boss's that might have their ability stop a music play something else for the ability duration and then restart the music.

Also tested these natives and they work fine.

First time trying to contribute to this plugin i might have done something wrong at somewhere please correct me if i have done so.